### PR TITLE
Fix the tests for blessed() so they don't break Test::More.

### DIFF
--- a/t/blessed.t
+++ b/t/blessed.t
@@ -34,13 +34,14 @@ $x = bless {}, "0";
 cmp_ok(blessed($x), "eq", "0",	'blessed HASH-ref');
 
 {
-  my $depth;
-  {
+  my $blessed = do {
+    my $depth;
     no warnings 'redefine';
-    *UNIVERSAL::can = sub { die "Burp!" if ++$depth > 2; blessed(shift) };
-  }
-  $x = bless {}, "DEF";
-  is(blessed($x), "DEF", 'recursion of UNIVERSAL::can');
+    local *UNIVERSAL::can = sub { die "Burp!" if ++$depth > 2; blessed(shift) };
+    $x = bless {}, "DEF";
+    blessed($x);
+  };
+  is($blessed, "DEF", 'recursion of UNIVERSAL::can');
 }
 
 {


### PR DESCRIPTION
Test::More might need UNIVERSAL::can, which blessed.t breaks.

This moves the bit that breaks UNIVERSAL::can into its own file which doesn't use a
test library.

Also reported on rt.cpan.org as 76171.
