### PR TITLE
add head() and tail() subs

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -559,6 +559,56 @@ PPCODE:
 }
 
 void
+head(size,...)
+PROTOTYPE: $@
+ALIAS:
+    head = 0
+    tail = 1
+PPCODE:
+{
+    int size = 0;
+    int start = 0;
+    int end = 0;
+    int i = 0;
+
+    size = SvIV( ST(0) );
+
+    if ( ix == 0 ) {
+        start = 1;
+        end = start + size;
+        if ( size < 0 ) {
+            end += items - 1;
+        }
+        if ( end > items ) {
+            end = items;
+        }
+    }
+    else {
+        end = items;
+        if ( size < 0 ) {
+            start = -size + 1;
+        }
+        else {
+            start = end - size;
+        }
+        if ( start < 1 ) {
+            start = 1;
+        }
+    }
+
+    if ( end < start ) {
+        XSRETURN(0);
+    }
+    else {
+        EXTEND( SP, end - start );
+        for ( i = start; i <= end; i++ ) {
+            PUSHs( sv_2mortal( newSVsv( ST(i) ) ) );
+        }
+        XSRETURN( end - start );
+    }
+}
+
+void
 pairs(...)
 PROTOTYPE: @
 PPCODE:

--- a/lib/List/Util.pm
+++ b/lib/List/Util.pm
@@ -13,7 +13,7 @@ require Exporter;
 our @ISA        = qw(Exporter);
 our @EXPORT_OK  = qw(
   all any first min max minstr maxstr none notall product reduce sum sum0 shuffle uniq uniqnum uniqstr
-  pairs unpairs pairkeys pairvalues pairmap pairgrep pairfirst
+  head tail pairs unpairs pairkeys pairvalues pairmap pairgrep pairfirst
 );
 our $VERSION    = "1.45";
 our $XS_VERSION = $VERSION;
@@ -539,6 +539,32 @@ C<undef> in the returned list is coerced into an empty string, so that the
 entire list of values returned by C<uniqstr> are well-behaved as strings.
 
 =cut
+
+=head2 head
+
+    my @values = head $size, @list;
+
+Returns the first C<$size> elements from C<@list>. If C<$size> is negative, returns
+all but the last C<$size> elements from C<@list>.
+
+    @result = head 2, qw( foo bar baz );
+    # foo, bar
+
+    @result = head -2, qw( foo bar baz );
+    # foo
+
+=head2 tail
+
+    my @values = tail $size, @list;
+
+Returns the last C<$size> elements from C<@list>. If C<$size> is negative, returns
+all but the first C<$size> elements from C<@list>.
+
+    @result = tail 2, qw( foo bar baz );
+    # bar, baz
+
+    @result = tail -2, qw( foo bar baz );
+    # baz
 
 =head1 KNOWN BUGS
 

--- a/t/head-tail.t
+++ b/t/head-tail.t
@@ -1,0 +1,97 @@
+#!./perl
+
+use strict;
+use warnings;
+
+use List::Util qw(head tail);
+use Test::More;
+plan tests => 42;
+
+my @ary;
+
+ok(defined &head, 'defined');
+ok(defined &tail, 'defined');
+
+@ary = head 1, ( 4, 5, 6 );
+is( scalar @ary, 1 );
+is( $ary[0], 4 );
+
+@ary = head 2, ( 4, 5, 6 );
+is( scalar @ary, 2 );
+is( $ary[0], 4 );
+is( $ary[1], 5 );
+
+@ary = head -1, ( 4, 5, 6 );
+is( scalar @ary, 2 );
+is( $ary[0], 4 );
+is( $ary[1], 5 );
+
+@ary = head -2, ( 4, 5, 6 );
+is( scalar @ary, 1 );
+is( $ary[0], 4 );
+
+@ary = head 999, ( 4, 5, 6 );
+is( scalar @ary, 3 );
+is( $ary[0], 4 );
+is( $ary[1], 5 );
+is( $ary[2], 6 );
+
+@ary = head 0, ( 4, 5, 6 );
+is( scalar @ary, 0 );
+
+@ary = head 0;
+is( scalar @ary, 0 );
+
+@ary = head 5;
+is( scalar @ary, 0 );
+
+@ary = head -3, ( 4, 5, 6 );
+is( scalar @ary, 0 );
+
+@ary = head -999, ( 4, 5, 6 );
+is( scalar @ary, 0 );
+
+eval '@ary = head';
+like( $@, qr{^Not enough arguments for List::Util::head} );
+
+@ary = head 4, ( 4, 5, 6 );
+is( scalar @ary, 3 );
+is( $ary[0], 4 );
+is( $ary[1], 5 );
+is( $ary[2], 6 );
+
+@ary = tail 1, ( 4, 5, 6 );
+is( scalar @ary, 1 );
+is( $ary[0], 6 );
+
+@ary = tail 2, ( 4, 5, 6 );
+is( scalar @ary, 2 );
+is( $ary[0], 5 );
+is( $ary[1], 6 );
+
+@ary = tail -1, ( 4, 5, 6 );
+is( scalar @ary, 2 );
+is( $ary[0], 5 );
+is( $ary[1], 6 );
+
+@ary = tail -2, ( 4, 5, 6 );
+is( scalar @ary, 1 );
+is( $ary[0], 6 );
+
+@ary = tail 0, ( 4, 5, 6 );
+is( scalar @ary, 0 );
+
+@ary = tail 0;
+is( scalar @ary, 0 );
+
+@ary = tail 5;
+is( scalar @ary, 0 );
+
+@ary = tail -3;
+is( scalar @ary, 0 );
+
+@ary = tail -999;
+is( scalar @ary, 0 );
+
+eval '@ary = tail';
+like( $@, qr{^Not enough arguments for List::Util::tail} );


### PR DESCRIPTION
`head( $n, @list )` grabs the first `$n` elements from `@list`, or if `$n` is
negative, all but the last `$n` elements.

`tail( $n, @list )` grabs the last `$n` elements from `@list`, or if `$n` is
negative, all but the first `$n elements.

These are useful if you need to slice a list and do not want to assign
it to a temporary array. For example, as part of a map/grep/sort/etc...
chain.

---

With this setup, a slice() sub would be pretty trivial. If this stuff isn't appropriate for List::Util, I could make them into their own dist.
