### PR TITLE
Add pick() function to pick a single random item from the input list

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1041,19 +1041,42 @@ CODE:
 }
 
 void
-pick(...)
-PROTOTYPE: @
+pick(num, ...)
+    int num;
+PROTOTYPE: $@
 CODE:
 {
     my_init_rand();
 
-    if ( items <= 0 ) {
-        XSRETURN_UNDEF;
+    if ( num <= 0 || items <= 1 ) {
+        XSRETURN_EMPTY;
     }
 
-    int index = (int)(Drand01() * (double)(items));
-    ST(0) = ST(index);
-    XSRETURN(1);
+    if ( num > items - 1 ) {
+        num = items - 1;
+    }
+
+    int found[num];
+    int i = 0;
+    while ( i < num ) {
+        bool redo = false;
+        int index = (int)(Drand01() * (double)(items-1));
+        for ( int x = 0; x < i; x++ ) {
+            if ( found[x] == index ) {
+                redo = true;
+                break;
+            }
+        }
+        if ( redo == true ) {
+            continue;
+        }
+
+        ST(i) = ST(index+1);
+        found[i] = index;
+        i++;
+    }
+
+    XSRETURN(i);
 }
 
 void

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -114,6 +114,32 @@ static enum slu_accum accum_type(SV *sv) {
 /* Magic for set_subname */
 static MGVTBL subname_vtbl;
 
+/* Initialize Perl's rand() function */
+void my_init_rand() {
+#if (PERL_VERSION < 9)
+    struct op dmy_op;
+    struct op *old_op = PL_op;
+
+    /* We call pp_rand here so that Drand01 get initialized if rand()
+       or srand() has not already been called
+    */
+    memzero((char*)(&dmy_op), sizeof(struct op));
+    /* we let pp_rand() borrow the TARG allocated for this XS sub */
+    dmy_op.op_targ = PL_op->op_targ;
+    PL_op = &dmy_op;
+    (void)*(PL_ppaddr[OP_RAND])(aTHX);
+    PL_op = old_op;
+#else
+    /* Initialize Drand01 if rand() or srand() has
+       not already been called
+    */
+    if(!PL_srand_called) {
+        (void)seedDrand01((Rand_seed_t)Perl_seed(aTHX));
+        PL_srand_called = TRUE;
+    }
+#endif
+}
+
 MODULE=List::Util       PACKAGE=List::Util
 
 void
@@ -1002,28 +1028,7 @@ PROTOTYPE: @
 CODE:
 {
     int index;
-#if (PERL_VERSION < 9)
-    struct op dmy_op;
-    struct op *old_op = PL_op;
-
-    /* We call pp_rand here so that Drand01 get initialized if rand()
-       or srand() has not already been called
-    */
-    memzero((char*)(&dmy_op), sizeof(struct op));
-    /* we let pp_rand() borrow the TARG allocated for this XS sub */
-    dmy_op.op_targ = PL_op->op_targ;
-    PL_op = &dmy_op;
-    (void)*(PL_ppaddr[OP_RAND])(aTHX);
-    PL_op = old_op;
-#else
-    /* Initialize Drand01 if rand() or srand() has
-       not already been called
-    */
-    if(!PL_srand_called) {
-        (void)seedDrand01((Rand_seed_t)Perl_seed(aTHX));
-        PL_srand_called = TRUE;
-    }
-#endif
+    my_init_rand();
 
     for (index = items ; index > 1 ; ) {
         int swap = (int)(Drand01() * (double)(index--));
@@ -1040,28 +1045,7 @@ pick(...)
 PROTOTYPE: @
 CODE:
 {
-#if (PERL_VERSION < 9)
-    struct op dmy_op;
-    struct op *old_op = PL_op;
-
-    /* We call pp_rand here so that Drand01 get initialized if rand()
-       or srand() has not already been called
-    */
-    memzero((char*)(&dmy_op), sizeof(struct op));
-    /* we let pp_rand() borrow the TARG allocated for this XS sub */
-    dmy_op.op_targ = PL_op->op_targ;
-    PL_op = &dmy_op;
-    (void)*(PL_ppaddr[OP_RAND])(aTHX);
-    PL_op = old_op;
-#else
-    /* Initialize Drand01 if rand() or srand() has
-       not already been called
-    */
-    if(!PL_srand_called) {
-        (void)seedDrand01((Rand_seed_t)Perl_seed(aTHX));
-        PL_srand_called = TRUE;
-    }
-#endif
+    my_init_rand();
 
     if ( items <= 0 ) {
         XSRETURN_UNDEF;

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1035,6 +1035,42 @@ CODE:
     XSRETURN(items);
 }
 
+void
+pick(...)
+PROTOTYPE: @
+CODE:
+{
+#if (PERL_VERSION < 9)
+    struct op dmy_op;
+    struct op *old_op = PL_op;
+
+    /* We call pp_rand here so that Drand01 get initialized if rand()
+       or srand() has not already been called
+    */
+    memzero((char*)(&dmy_op), sizeof(struct op));
+    /* we let pp_rand() borrow the TARG allocated for this XS sub */
+    dmy_op.op_targ = PL_op->op_targ;
+    PL_op = &dmy_op;
+    (void)*(PL_ppaddr[OP_RAND])(aTHX);
+    PL_op = old_op;
+#else
+    /* Initialize Drand01 if rand() or srand() has
+       not already been called
+    */
+    if(!PL_srand_called) {
+        (void)seedDrand01((Rand_seed_t)Perl_seed(aTHX));
+        PL_srand_called = TRUE;
+    }
+#endif
+
+    if ( items <= 0 ) {
+        XSRETURN_UNDEF;
+    }
+
+    int index = (int)(Drand01() * (double)(items));
+    ST(0) = ST(index);
+    XSRETURN(1);
+}
 
 void
 uniq(...)

--- a/lib/List/Util.pm
+++ b/lib/List/Util.pm
@@ -12,7 +12,7 @@ require Exporter;
 
 our @ISA        = qw(Exporter);
 our @EXPORT_OK  = qw(
-  all any first min max minstr maxstr none notall product reduce sum sum0 shuffle uniq uniqnum uniqstr
+  all any first min max minstr maxstr none notall product reduce sum sum0 shuffle pick uniq uniqnum uniqstr
   pairs unpairs pairkeys pairvalues pairmap pairgrep pairfirst
 );
 our $VERSION    = "1.47";
@@ -52,7 +52,7 @@ List::Util - A selection of general-utility list subroutines
 
       pairs unpairs pairkeys pairvalues pairfirst pairgrep pairmap
 
-      shuffle uniq uniqnum uniqstr
+      pick shuffle uniq uniqnum uniqstr
     );
 
 =head1 DESCRIPTION
@@ -484,6 +484,14 @@ See L</KNOWN BUGS> for a known-bug with C<pairmap>, and a workaround.
 Returns the values of the input in a random order
 
     @cards = shuffle 0..51      # 0..51 in a random order
+
+=head2 pick
+
+    my $value = pick @values;
+
+Returns a single random value from the input list.
+
+    my $num = pick 1..10;       # Pick a number from 1 to 10
 
 =head2 uniq
 

--- a/lib/List/Util.pm
+++ b/lib/List/Util.pm
@@ -487,11 +487,14 @@ Returns the values of the input in a random order
 
 =head2 pick
 
-    my $value = pick @values;
+    my $value = pick $count, @values;
 
-Returns a single random value from the input list.
+Returns a number of random values from the input list (up to $count). No
+individual item is picked more than once. If $count is more than the
+number of values, returns a shuffled values list.
 
-    my $num = pick 1..10;       # Pick a number from 1 to 10
+    my $num = pick 1 => 1..10;       # Pick a number from 1 to 10
+    my @hand = pick 5 => @cards;     # Pick 5 items from the deck of cards
 
 =head2 uniq
 

--- a/t/pick.t
+++ b/t/pick.t
@@ -3,21 +3,41 @@
 use strict;
 use warnings;
 
-use Test::More tests => 4;
+use Test::More tests => 14;
 
 use List::Util qw(pick);
 
-my $i;
-
-$i = pick();
-ok( !$i, 'no args' );
-
-my @items = pick();
-is( scalar @items, 1, 'pick always returns a scalar' );
+my ( $i, @items );
 
 $i = pick( 1 );
+ok( !$i, 'no list to pick from' );
+@items = pick( 1 );
+is( scalar @items, 0, 'pick returns empty list if no list given' );
+
+$i = pick( 0 );
+ok( !$i, 'no list to pick from' );
+@items = pick( 0 );
+is( scalar @items, 0, 'pick always returns the correct number of items' );
+
+$i = pick( 0, 1, 2, 3, 4 );
+ok( !$i, 'pick 0 items' );
+@items = pick( 0, 1, 2, 3, 4 );
+is( scalar @items, 0, 'pick returns empty list if no list given' );
+
+$i = pick( 1, 1 );
 is( $i, 1, 'one in, 1 out' );
 
-$i = pick( 2, 2, 2, 2, 2, 2 );
-is( $i, 2, 'a bunch in, one out' );
+@items = pick( 2, 2, 2, 2, 2, 2 );
+is( scalar @items, 2, 'asked for 2 got 2' );
+is( $items[0], 2, 'a bunch in, two out' );
+is( $items[1], 2, 'a bunch in, two out' );
 
+@items = pick( 2, 1, 2 );
+is( scalar @items, 2, 'asked for 2 got 2' );
+ok +(
+    ( $items[0] == 1 && $items[1] == 2 ) || ( $items[0] == 2 && $items[1] == 1 )
+   ), 'each item picked only once';
+
+@items = pick( 2, 1 );
+is( scalar @items, 1, 'only one item to pick from' );
+is( $items[0], 1, 'got the right item' );

--- a/t/pick.t
+++ b/t/pick.t
@@ -1,0 +1,23 @@
+#!./perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 4;
+
+use List::Util qw(pick);
+
+my $i;
+
+$i = pick();
+ok( !$i, 'no args' );
+
+my @items = pick();
+is( scalar @items, 1, 'pick always returns a scalar' );
+
+$i = pick( 1 );
+is( $i, 1, 'one in, 1 out' );
+
+$i = pick( 2, 2, 2, 2, 2, 2 );
+is( $i, 2, 'a bunch in, one out' );
+


### PR DESCRIPTION
This PR adds a `pick()` function that will pick a single random item from the input list. This is like the [Perl 6 pick routine](https://doc.perl6.org/routine/pick), except the count is always 1 (I can add a count argument if desired).

This is faster than using `shuffle()` and picking the first one, and is more convenient for picking a number from a range:

```
# Pick a number from 10-99
my $num = int( rand 90 + 10 );

use List::Util qw( pick );
my $num = pick 10..99;
```
