### PR TITLE
Fix indentation

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -952,11 +952,13 @@ PPCODE:
                     stack[reti++] = newSVsv(PL_stack_base[i + 1]);
         }
 
-        if (spill)
+        if (spill) {
             /* the POP_MULTICALL will trigger the SAVEFREESV above;
              * keep it alive  it on the temps stack instead */
             SvREFCNT_inc_simple_void_NN(spill);
-            sv_2mortal((SV*)spill);
+        }
+
+        sv_2mortal((SV*)spill);
 
         POP_MULTICALL;
 


### PR DESCRIPTION
Nesting level doesn't match indentation and makes feel that "sv_2mortal"
is part of "if (spill)" branch, while it isn't.

For rt123781, done as part of CPAN Pull Request Challenge.