### PR TITLE
Add appveyor config for testing on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,15 @@
+cache:
+  - C:\strawberry
+
+install:
+  - if not exist "C:\strawberry" choco install strawberryperl -y
+  - set PATH=C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - cpanm --quiet --installdeps --with-develop --notest .
+
+build_script:
+  - perl Makefile.PL
+  - gmake
+
+test_script:
+  - gmake test


### PR DESCRIPTION
This commit is done as part of the CPAN Pull Request Challenge 2017.
Basic appveyor config to test that the module build on Windows.