### PR TITLE
Fix set_subname with exotic names

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1485,7 +1485,8 @@ PREINIT:
     STRLEN namelen;
     const char* nameptr = SvPV(name, namelen);
     int utf8flag = SvUTF8(name);
-    int seen_quote = 0, need_subst = 0;
+    int quotes_seen = 0;
+    bool need_subst = FALSE;
 PPCODE:
     if (!SvROK(sub) && SvGMAGICAL(sub))
         mg_get(sub);
@@ -1508,21 +1509,21 @@ PPCODE:
         if (s > nameptr && *s == ':' && s[-1] == ':') {
             end = s - 1;
             begin = ++s;
-            if (seen_quote)
-                need_subst++;
+            if (quotes_seen)
+                need_subst = TRUE;
         }
         else if (s > nameptr && *s != '\0' && s[-1] == '\'') {
             end = s - 1;
             begin = s;
-            if (seen_quote++)
-                need_subst++;
+            if (quotes_seen++)
+                need_subst = TRUE;
         }
     }
     s--;
     if (end) {
         SV* tmp;
         if (need_subst) {
-            STRLEN length = end - nameptr + seen_quote - (*end == '\'' ? 1 : 0);
+            STRLEN length = end - nameptr + quotes_seen - (*end == '\'' ? 1 : 0);
             char* left;
             int i, j;
             tmp = newSV(length);

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1487,6 +1487,7 @@ PPCODE:
         namelen -= end - nameptr;
     }
 
+    #ifdef PERL_VERSION < 10
     /* under debugger, provide information about sub location */
     if (PL_DBsub && CvGV(cv)) {
         HV *hv = GvHV(PL_DBsub);
@@ -1521,6 +1522,7 @@ PPCODE:
         }
         Safefree(full_name);
     }
+    #endif
 
     gv = (GV *) newSV(0);
     gv_init_pvn(gv, stash, nameptr, s - nameptr, GV_ADDMULTI | utf8flag);

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1454,8 +1454,8 @@ PREINIT:
     const char *s, *end = NULL, *begin = NULL;
     MAGIC *mg;
     STRLEN namelen;
-    int utf8flag = SvUTF8(name);
     const char* nameptr = SvPV(name, namelen);
+    int utf8flag = SvUTF8(name);
     int seen_quote = 0, need_subst = 0;
 PPCODE:
     if (!SvROK(sub) && SvGMAGICAL(sub))

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1526,7 +1526,7 @@ PPCODE:
             STRLEN length = end - nameptr + quotes_seen - (*end == '\'' ? 1 : 0);
             char* left;
             int i, j;
-            tmp = newSV(length);
+            tmp = sv_2mortal(newSV(length));
             left = SvPVX(tmp);
             for (i = 0, j = 0; j < end - nameptr; ++i, ++j) {
                 if (nameptr[j] == '\'') {
@@ -1538,7 +1538,6 @@ PPCODE:
                 }
             }
             stash = gv_stashpvn(left, length, GV_ADD | utf8flag);
-            SvREFCNT_dec(tmp);
         }
         else
             stash = gv_stashpvn(nameptr, end - nameptr, GV_ADD | utf8flag);
@@ -1553,22 +1552,19 @@ PPCODE:
 
         GV* oldgv = CvGV(cv);
         HV* oldhv = GvSTASH(oldgv);
-        SV* old_full_name = newSVpvn_flags(HvNAME(oldhv), HvNAMELEN_get(oldhv), HvNAMEUTF8(oldhv) ? SVf_UTF8 : 0);
+        SV* old_full_name = sv_2mortal(newSVpvn_flags(HvNAME(oldhv), HvNAMELEN_get(oldhv), HvNAMEUTF8(oldhv) ? SVf_UTF8 : 0));
         sv_catpvn(old_full_name, "::", 2);
         sv_catpvn_flags(old_full_name, GvNAME(oldgv), GvNAMELEN(oldgv), GvNAMEUTF8(oldgv) ? SV_CATUTF8 : SV_CATBYTES);
 
         old_data = hv_fetch_ent(DBsub, old_full_name, 0, 0);
 
-        SvREFCNT_dec(old_full_name);
-
         if (old_data && HeVAL(old_data)) {
-            SV* new_full_name = newSVpvn_flags(HvNAME(stash), HvNAMELEN_get(stash), HvNAMEUTF8(stash) ? SVf_UTF8 : 0);
+            SV* new_full_name = sv_2mortal(newSVpvn_flags(HvNAME(stash), HvNAMELEN_get(stash), HvNAMEUTF8(stash) ? SVf_UTF8 : 0));
             sv_catpvn(new_full_name, "::", 2);
             sv_catpvn_flags(new_full_name, nameptr, s - nameptr, utf8flag ? SV_CATUTF8 : SV_CATBYTES);
             SvREFCNT_inc(HeVAL(old_data));
             if (hv_store_ent(DBsub, new_full_name, HeVAL(old_data), 0) != NULL)
                 SvREFCNT_inc(HeVAL(old_data));
-            SvREFCNT_dec(new_full_name);
         }
     }
 

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -10,6 +10,7 @@
 #ifdef USE_PPPORT_H
 #  define NEED_sv_2pv_flags 1
 #  define NEED_newSVpvn_flags 1
+#  define NEED_sv_catpvn_flags
 #  include "ppport.h"
 #endif
 
@@ -65,6 +66,10 @@
 
 #ifndef SV_CATBYTES
 #define SV_CATBYTES 0
+#endif
+
+#ifndef sv_catpvn_flags
+#define sv_catpvn_flags(b,n,l,f) sv_catpvn(b,n,l)
 #endif
 
 /* Some platforms have strict exports. And before 5.7.3 cxinc (or Perl_cxinc)

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1476,13 +1476,13 @@ PPCODE:
     if (SvTYPE(cv) != SVt_PVCV && SvTYPE(cv) != SVt_PVFM)
         croak("Not a subroutine reference");
     for (s = nameptr; s <= nameptr + namelen; s++) {
-        if (*s == ':' && s[-1] == ':') {
+        if (s > nameptr && *s == ':' && s[-1] == ':') {
             end = s - 1;
             begin = ++s;
             if (seen_quote)
                 need_subst++;
         }
-        else if (*s && s[-1] == '\'') {
+        else if (s > nameptr && *s != '\0' && s[-1] == '\'') {
             end = s - 1;
             begin = s;
             if (seen_quote++)

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1445,14 +1445,17 @@ PPCODE:
 
 void
 set_subname(name, sub)
-    char *name
+    SV *name
     SV *sub
 PREINIT:
     CV *cv = NULL;
     GV *gv;
     HV *stash = CopSTASH(PL_curcop);
-    char *s, *end = NULL;
+    const char *s, *end = NULL;
     MAGIC *mg;
+    STRLEN namelen;
+    int utf8flag = SvUTF8(name);
+    const char* nameptr = SvPV(name, namelen);
 PPCODE:
     if (!SvROK(sub) && SvGMAGICAL(sub))
         mg_get(sub);
@@ -1465,13 +1468,13 @@ PPCODE:
     else if (PL_op->op_private & HINT_STRICT_REFS)
         croak("Can't use string (\"%.32s\") as %s ref while \"strict refs\" in use",
               SvPV_nolen(sub), "a subroutine");
-    else if ((gv = gv_fetchpv(SvPV_nolen(sub), FALSE, SVt_PVCV)))
+    else if ((gv = gv_fetchsv(sub, FALSE, SVt_PVCV)))
         cv = GvCVu(gv);
     if (!cv)
         croak("Undefined subroutine %s", SvPV_nolen(sub));
     if (SvTYPE(cv) != SVt_PVCV && SvTYPE(cv) != SVt_PVFM)
         croak("Not a subroutine reference");
-    for (s = name; *s++; ) {
+    for (s = nameptr; s <= nameptr + namelen; s++) {
         if (*s == ':' && s[-1] == ':')
             end = ++s;
         else if (*s && s[-1] == '\'')
@@ -1479,10 +1482,9 @@ PPCODE:
     }
     s--;
     if (end) {
-        char *namepv = savepvn(name, end - name);
-        stash = GvHV(gv_fetchpv(namepv, TRUE, SVt_PVHV));
-        Safefree(namepv);
-        name = end;
+        stash = GvHV(gv_fetchpvn_flags(nameptr, end - nameptr, GV_ADD | utf8flag, SVt_PVHV));
+        nameptr = end;
+        namelen -= end - nameptr;
     }
 
     /* under debugger, provide information about sub location */
@@ -1495,7 +1497,7 @@ PPCODE:
         char *old_pkg = HvNAME( GvSTASH(CvGV(cv)) );
 
         int old_len = strlen(old_name) + strlen(old_pkg);
-        int new_len = strlen(name) + strlen(new_pkg);
+        int new_len = namelen + strlen(new_pkg);
 
         SV **old_data;
         char *full_name;
@@ -1511,7 +1513,7 @@ PPCODE:
         if (old_data) {
             strcpy(full_name, new_pkg);
             strcat(full_name, "::");
-            strcat(full_name, name);
+            strcat(full_name, nameptr);
 
             SvREFCNT_inc(*old_data);
             if (!hv_store(hv, full_name, strlen(full_name), *old_data, 0))
@@ -1521,7 +1523,7 @@ PPCODE:
     }
 
     gv = (GV *) newSV(0);
-    gv_init(gv, stash, name, s - name, TRUE);
+    gv_init_pvn(gv, stash, nameptr, s - nameptr, GV_ADDMULTI | utf8flag);
 
     /*
      * set_subname needs to create a GV to store the name. The CvGV field of a

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -43,6 +43,30 @@
 #  define CvISXSUB(cv) CvXSUB(cv)
 #endif
 
+#ifndef HvNAMELEN_get
+#define HvNAMELEN_get(stash) strlen(HvNAME(stash))
+#endif
+
+#ifndef HvNAMEUTF8
+#define HvNAMEUTF8(stash) 0
+#endif
+
+#ifndef GvNAMEUTF8
+#ifdef GvNAME_HEK
+#define GvNAMEUTF8(gv) HEK_UTF8(GvNAME_HEK(gv))
+#else
+#define GvNAMEUTF8(gv) 0
+#endif
+#endif
+
+#ifndef SV_CATUTF8
+#define SV_CATUTF8 0
+#endif
+
+#ifndef SV_CATBYTES
+#define SV_CATBYTES 0
+#endif
+
 /* Some platforms have strict exports. And before 5.7.3 cxinc (or Perl_cxinc)
    was not exported. Therefore platforms like win32, VMS etc have problems
    so we redefine it here -- GMB
@@ -1516,42 +1540,31 @@ PPCODE:
         namelen -= begin - nameptr;
     }
 
-    #ifdef PERL_VERSION < 10
     /* under debugger, provide information about sub location */
     if (PL_DBsub && CvGV(cv)) {
-        HV *hv = GvHV(PL_DBsub);
+        HV* DBsub = GvHV(PL_DBsub);
+        HE* old_data;
 
-        char *new_pkg = HvNAME(stash);
+        GV* oldgv = CvGV(cv);
+        HV* oldhv = GvSTASH(oldgv);
+        SV* old_full_name = newSVpvn_flags(HvNAME(oldhv), HvNAMELEN_get(oldhv), HvNAMEUTF8(oldhv) ? SVf_UTF8 : 0);
+        sv_catpvn(old_full_name, "::", 2);
+        sv_catpvn_flags(old_full_name, GvNAME(oldgv), GvNAMELEN(oldgv), GvNAMEUTF8(oldgv) ? SV_CATUTF8 : SV_CATBYTES);
 
-        char *old_name = GvNAME( CvGV(cv) );
-        char *old_pkg = HvNAME( GvSTASH(CvGV(cv)) );
+        old_data = hv_fetch_ent(DBsub, old_full_name, 0, 0);
 
-        int old_len = strlen(old_name) + strlen(old_pkg);
-        int new_len = namelen + strlen(new_pkg);
+        SvREFCNT_dec(old_full_name);
 
-        SV **old_data;
-        char *full_name;
-
-        Newxz(full_name, (old_len > new_len ? old_len : new_len) + 3, char);
-
-        strcat(full_name, old_pkg);
-        strcat(full_name, "::");
-        strcat(full_name, old_name);
-
-        old_data = hv_fetch(hv, full_name, strlen(full_name), 0);
-
-        if (old_data) {
-            strcpy(full_name, new_pkg);
-            strcat(full_name, "::");
-            strcat(full_name, nameptr);
-
-            SvREFCNT_inc(*old_data);
-            if (!hv_store(hv, full_name, strlen(full_name), *old_data, 0))
-                SvREFCNT_dec(*old_data);
+        if (old_data && HeVAL(old_data)) {
+            SV* new_full_name = newSVpvn_flags(HvNAME(stash), HvNAMELEN_get(stash), HvNAMEUTF8(stash) ? SVf_UTF8 : 0);
+            sv_catpvn(new_full_name, "::", 2);
+            sv_catpvn_flags(new_full_name, nameptr, s - nameptr, utf8flag ? SV_CATUTF8 : SV_CATBYTES);
+            SvREFCNT_inc(HeVAL(old_data));
+            if (hv_store_ent(DBsub, new_full_name, HeVAL(old_data), 0) != NULL)
+                SvREFCNT_inc(HeVAL(old_data));
+            SvREFCNT_dec(new_full_name);
         }
-        Safefree(full_name);
     }
-    #endif
 
     gv = (GV *) newSV(0);
     gv_init_pvn(gv, stash, nameptr, s - nameptr, GV_ADDMULTI | utf8flag);

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1480,24 +1480,25 @@ PPCODE:
             end = s - 1;
             begin = ++s;
             if (seen_quote)
-                seen_quote++;
+                need_subst++;
         }
         else if (*s && s[-1] == '\'') {
             end = s - 1;
             begin = s;
-            seen_quote++;
+            if (seen_quote++)
+                need_subst++;
         }
     }
     s--;
     if (end) {
         SV* tmp;
-        if (seen_quote > 1) {
-            STRLEN length = end - nameptr + seen_quote;
+        if (need_subst) {
+            STRLEN length = end - nameptr + seen_quote - (*end == '\'' ? 1 : 0);
             char* left;
             int i, j;
             tmp = newSV(length);
             left = SvPVX(tmp);
-            for (i = 0, j = 0; j <= end - nameptr; ++i, ++j) {
+            for (i = 0, j = 0; j < end - nameptr; ++i, ++j) {
                 if (nameptr[j] == '\'') {
                     left[i] = ':';
                     left[++i] = ':';
@@ -1506,7 +1507,7 @@ PPCODE:
                     left[i] = nameptr[j];
                 }
             }
-            stash = gv_stashpvn(left, i - 2, GV_ADD | utf8flag);
+            stash = gv_stashpvn(left, length, GV_ADD | utf8flag);
             SvREFCNT_dec(tmp);
         }
         else

--- a/t/exotic_names.t
+++ b/t/exotic_names.t
@@ -11,6 +11,13 @@ use B 'svref_2object';
 # a heuristic with ambiguous eval and looking for octets in the stash
 use if $] >= 5.016, feature => 'unicode_eval';
 
+if ($] >= 5.008) {
+	my $builder = Test::More->builder;
+	binmode $builder->output,         ":encoding(utf8)";
+	binmode $builder->failure_output, ":encoding(utf8)";
+	binmode $builder->todo_output,    ":encoding(utf8)";
+}
+
 sub compile_named_sub {
     my ( $fullname, $body ) = @_;
     my $sub = eval "sub $fullname { $body }" . '\\&{$fullname}';

--- a/t/exotic_names.t
+++ b/t/exotic_names.t
@@ -50,6 +50,8 @@ sub caller3_ok {
 
 #######################################################################
 
+use Sub::Util 'set_subname';
+
 my @ordinal = ( 1 .. 255 );
 
 # 5.14 is the first perl to start properly handling \0 in identifiers
@@ -64,7 +66,7 @@ push @ordinal,
     0x1f4a9,  # PILE OF POO
     unless $] < 5.008;
 
-plan tests => @ordinal * 2;
+plan tests => @ordinal * 2 * 2;
 
 my $legal_ident_char = "A-Z_a-z0-9'";
 $legal_ident_char .= join '', map chr, 0x100, 0x498
@@ -75,6 +77,9 @@ for my $ord (@ordinal) {
     my $pkg      = sprintf 'test::SOME_%c_STASH', $ord;
     my $subname  = sprintf 'SOME_%c_NAME', $ord;
     my $fullname = join '::', $pkg, $subname;
+
+    $sub = set_subname $fullname => sub { (caller(0))[3] };
+    caller3_ok $sub, $fullname, 'renamed closure', $ord;
 
     # test that we can *always* compile at least within the correct package
     my $expected;

--- a/t/exotic_names.t
+++ b/t/exotic_names.t
@@ -1,0 +1,91 @@
+use strict;
+use warnings;
+
+use Test::More;
+use B 'svref_2object';
+
+# This is a mess. The stash can supposedly handle Unicode but the behavior
+# is literally undefined before 5.16 (with crashes beyond the basic plane),
+# and remains unclear past 5.16 with evalbytes and feature unicode_eval
+# In any case - Sub::Name needs to *somehow* work with this, so we will do
+# a heuristic with ambiguous eval and looking for octets in the stash
+use if $] >= 5.016, feature => 'unicode_eval';
+
+sub compile_named_sub {
+    my ( $fullname, $body ) = @_;
+    my $sub = eval "sub $fullname { $body }" . '\\&{$fullname}';
+    return $sub if $sub;
+    my $e = $@;
+    require Carp;
+    Carp::croak $e;
+}
+
+sub caller3_ok {
+    my ( $sub, $expected, $type, $ord ) = @_;
+
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+    my $for_what = sprintf "when it contains \\x%s ( %s )", (
+        ( ($ord > 255)
+            ? sprintf "{%X}", $ord
+            : sprintf "%02X", $ord
+        ),
+        (
+            $ord > 255                    ? unpack('H*', pack 'C0U', $ord )
+            : ($ord > 0x1f and $ord < 0x7f) ? sprintf "%c", $ord
+            :                                 sprintf '\%o', $ord
+        ),
+    );
+
+    $expected =~ s/'/::/g;
+
+    # this is apparently how things worked before 5.16
+    utf8::encode($expected) if $] < 5.016 and $ord > 255;
+
+    my $stash_name = join '::', map { $_->STASH->NAME, $_->NAME } svref_2object($sub)->GV;
+
+    is $stash_name, $expected, "stash name for $type is correct $for_what";
+    is $sub->(), $expected, "caller() in $type returns correct name $for_what";
+}
+
+#######################################################################
+
+my @ordinal = ( 1 .. 255 );
+
+# 5.14 is the first perl to start properly handling \0 in identifiers
+unshift @ordinal, 0
+    unless $] < 5.014;
+
+# Unicode in 5.6 is not sane (crashes etc)
+push @ordinal,
+    0x100,    # LATIN CAPITAL LETTER A WITH MACRON
+    0x498,    # CYRILLIC CAPITAL LETTER ZE WITH DESCENDER
+    0x2122,   # TRADE MARK SIGN
+    0x1f4a9,  # PILE OF POO
+    unless $] < 5.008;
+
+plan tests => @ordinal * 2;
+
+my $legal_ident_char = "A-Z_a-z0-9'";
+$legal_ident_char .= join '', map chr, 0x100, 0x498
+    unless $] < 5.008;
+
+for my $ord (@ordinal) {
+    my $sub;
+    my $pkg      = sprintf 'test::SOME_%c_STASH', $ord;
+    my $subname  = sprintf 'SOME_%c_NAME', $ord;
+    my $fullname = join '::', $pkg, $subname;
+
+    # test that we can *always* compile at least within the correct package
+    my $expected;
+    if ( chr($ord) =~ m/^[$legal_ident_char]$/o ) { # compile directly
+        $expected = $fullname;
+        $sub = compile_named_sub $fullname => '(caller(0))[3]';
+    }
+    else { # not a legal identifier but at least test the package name by aliasing
+        $expected = "${pkg}::foo";
+        { no strict 'refs'; *palatable:: = *{"${pkg}::"} } # now palatable:: literally means ${pkg}::
+        $sub = compile_named_sub 'palatable::foo' => '(caller(0))[3]';
+    }
+    caller3_ok $sub, $expected, 'natively compiled sub', $ord;
+}

--- a/t/exotic_names.t
+++ b/t/exotic_names.t
@@ -104,8 +104,10 @@ for my $ord (@ordinal) {
           no strict 'refs';
           *palatable:: = *{"aliased::native::${pkg}::"};
           # now palatable:: literally means aliased::native::${pkg}::
-          ${"palatable::$subname"} = 1;
-          ${"palatable::"}{"sub"} = ${"palatable::"}{$subname};
+          my $encoded_sub = $subname;
+          utf8::encode($encoded_sub) if "$]" < 5.016 and $ord > 255;
+          ${"palatable::$encoded_sub"} = 1;
+          ${"palatable::"}{"sub"} = ${"palatable::"}{$encoded_sub};
           # and palatable::sub means aliased::native::${pkg}::${subname}
         }
         $sub = compile_named_sub 'palatable::sub' => '(caller(0))[3]';

--- a/t/exotic_names.t
+++ b/t/exotic_names.t
@@ -99,9 +99,16 @@ for my $ord (@ordinal) {
         $sub = compile_named_sub $expected => '(caller(0))[3]';
     }
     else { # not a legal identifier but at least test the package name by aliasing
-        $expected = "${pkg}::foo";
-        { no strict 'refs'; *palatable:: = *{"${pkg}::"} } # now palatable:: literally means ${pkg}::
-        $sub = compile_named_sub 'palatable::foo' => '(caller(0))[3]';
+        $expected = "aliased::native::$fullname";
+        {
+          no strict 'refs';
+          *palatable:: = *{"aliased::native::${pkg}::"};
+          # now palatable:: literally means aliased::native::${pkg}::
+          ${"palatable::$subname"} = 1;
+          ${"palatable::"}{"sub"} = ${"palatable::"}{$subname};
+          # and palatable::sub means aliased::native::${pkg}::${subname}
+        }
+        $sub = compile_named_sub 'palatable::sub' => '(caller(0))[3]';
     }
     caller3_ok $sub, $expected, 'natively compiled sub', $ord;
 }

--- a/t/exotic_names.t
+++ b/t/exotic_names.t
@@ -54,7 +54,13 @@ sub caller3_ok {
 
     is $stash_name, $expected, "stash name for $type is correct $for_what";
     is $sub->(), $expected, "caller() in $type returns correct name $for_what";
-    ok $DB::sub{$expected}, "%DB::sub entry for $type is correct $for_what";
+    SKIP: {
+      skip '%DB::sub not populated when enabled at runtime', 1
+        unless keys %DB::sub;
+      my ($prefix) = $expected =~ /^(.*?test::[^:]+::)/;
+      my ($db_found) = grep /^$prefix/, keys %DB::sub;
+      is $db_found, $expected, "%DB::sub entry for $type is correct $for_what";
+    }
 }
 
 #######################################################################


### PR DESCRIPTION
This includes unicode and binary names.  Patches are primarily taken from Sub::Name.