### PR TITLE
Fix tests to work also on Perl 5.6.2

### DIFF
--- a/t/product.t
+++ b/t/product.t
@@ -113,11 +113,8 @@ SKIP: {
   $t = product($max, $min);
   is($t, (1<<31) - (1<<62), 'max * min');
 
-  SKIP: {
-  skip "known to fail on $]", 1 if $] le "5.006002";
   $t = product($max, $max);
-  is($t,  (1<<62)-(1<<32)+1, 'max * max');
-  }
+  is($t,  4611686014132420609, 'max * max'); # (1<<62)-(1<<32)+1), but Perl 5.6 does not compute constant correctly
 
   $t = product($min*8, $min);
   cmp_ok($t, '>',  (1<<61), 'min*8*min'); # may be an NV

--- a/t/sum.t
+++ b/t/sum.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 17;
+use Test::More tests => 18;
 
 use Config;
 use List::Util qw(sum);
@@ -91,15 +91,20 @@ is($v, $v1 + 42 + 2, 'bigint + builtin int');
 }
 
 SKIP: {
-  skip "IV is not at least 64bit", 3 unless $Config{ivsize} >= 8;
-  skip "known to fail on $]", 3 if $] le "5.006002";
+  skip "IV is not at least 64bit", 4 unless $Config{ivsize} >= 8;
 
   # Sum using NV will only preserve 53 bits of integer precision
-  my $t = sum(1<<60, 1);
-  cmp_ok($t, '>', 1<<60, 'sum uses IV where it can');
+  my $t = sum(1152921504606846976, 1); # 1<<60, but Perl 5.6 does not compute constant correctly
+  cmp_ok($t, 'gt', 1152921504606846976, 'sum uses IV where it can'); # string comparison because Perl 5.6 does not compare it numerically correctly
+
+  SKIP: {
+    skip "known to fail on $]", 1 if $] le "5.006002";
+    $t = sum(1<<60, 1);
+    cmp_ok($t, '>', 1<<60, 'sum uses IV where it can');
+  }
 
   my $min = -(1<<63);
-  my $max = (1<<63)-1;
+  my $max = 9223372036854775807; # (1<<63)-1, but Perl 5.6 does not compute constant correctly
 
   $t = sum($min, $max);
   is($t, -1, 'min + max');

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -132,9 +132,7 @@ is_deeply( [ uniq () ],
 
 is( scalar( uniqstr qw( a b c d a b e ) ), 5, 'uniqstr() in scalar context' );
 
-SKIP: {
-    skip "known to fail on $]", 1 if $] le "5.006002";
-
+{
     package Stringify;
 
     use overload '""' => sub { return $_[0]->{str} };


### PR DESCRIPTION
It is better to run tests instead of skipping them.