### PR TITLE
Fix segfaults in (set_)subname with deleted stashes

### DIFF
--- a/lib/Sub/Util.pm
+++ b/lib/Sub/Util.pm
@@ -95,8 +95,10 @@ I<Since version 1.40.>
 Returns the name of the given C<$code> reference, if it has one. Normal named
 subs will give a fully-qualified name consisting of the package and the
 localname separated by C<::>. Anonymous code references will give C<__ANON__>
-as the localname. If a name has been set using L</set_subname>, this name will
-be returned instead.
+as the localname. If the package the code was compiled in has been deleted
+(e.g. using C<delete_package> from L<Symbol>), C<__ANON__> will be returned as
+the package name. If a name has been set using L</set_subname>, this name will be
+returned instead.
 
 This function was inspired by C<sub_fullname> from L<Sub::Identify>. The
 remaining functions that C<Sub::Identify> implements can easily be emulated

--- a/t/subname.t
+++ b/t/subname.t
@@ -3,10 +3,11 @@ use warnings;
 
 BEGIN { $^P |= 0x210 }
 
-use Test::More tests => 18;
+use Test::More tests => 21;
 
 use B::Deparse;
 use Sub::Util qw( subname set_subname );
+use Symbol qw( delete_package ) ;
 
 {
   sub localfunc {}
@@ -76,6 +77,20 @@ is($x->(), "main::foo");
 {
   is(subname(set_subname "my-scary-name-here", sub {}), "main::my-scary-name-here",
     'subname of set_subname');
+}
+
+# this used to segfault
+
+{
+    sub ToDelete::foo {}
+
+    my $foo = \&ToDelete::foo;
+
+    delete_package 'ToDelete';
+
+    is( subname($foo), "$]" >= 5.010 ? '__ANON__::foo' : 'ToDelete::foo', 'subname in deleted package' );
+    ok( set_subname('NewPackage::foo', $foo), 'rename from deleted package' );
+    is( subname($foo), 'NewPackage::foo', 'subname after rename' );
 }
 
 # vim: ft=perl


### PR DESCRIPTION
Return `__ANON__` as the package name if the stash has been deleted.