### PR TITLE
Fix uniqnum on large stringified integers on long- and quad-double perls

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1177,8 +1177,13 @@ CODE:
                 /* clone the value so we don't invoke magic again */
                 arg = sv_mortalcopy(arg);
 
-            if(SvOK(arg) && !(SvUOK(arg) || SvIOK(arg) || SvNOK(arg)))
+            if(SvOK(arg) && !(SvUOK(arg) || SvIOK(arg) || SvNOK(arg))) {
+#if PERL_VERSION >= 8
                 SvIV(arg); /* sets SVf_IOK/SVf_IsUV if it's an integer */
+#else
+                SvNV(arg); /* SvIV() sets SVf_IOK even on floats on 5.6 */
+#endif
+            }
 
             if(!SvOK(arg) || SvUOK(arg))
                 sv_setpvf(keysv, "%" UVuf, SvUV(arg));

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1178,7 +1178,7 @@ CODE:
                 arg = sv_mortalcopy(arg);
 
             if(SvOK(arg) && !(SvUOK(arg) || SvIOK(arg) || SvNOK(arg)))
-                SvNV(arg); /* sets SVf_IOK/SVf_UOK if it's an integer */
+                SvIV(arg); /* sets SVf_IOK/SVf_IsUV if it's an integer */
 
             if(!SvOK(arg) || SvUOK(arg))
                 sv_setpvf(keysv, "%" UVuf, SvUV(arg));


### PR DESCRIPTION
Turns out long-double perls' `SvNV()` macro doesn't set the integer
flags even if the value is an integer.  Use `SvIV()` instead, which
appears to be doing the right thing for normal, long and quad doubles.