### PR TITLE
Corrections to uniqnum

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1227,7 +1227,7 @@ CODE:
 
                 int_arg = SvIV(arg);
 
-                if(int_arg < -4503599627370496 
+                if(int_arg < -9007199254740992 
                     ||
                    int_arg > 9007199254740992)  /* IV to NV conversion could lose precision */
                     potential_prec_loss = 1;
@@ -1279,10 +1279,10 @@ CODE:
                 /* Take appropriate action if nv_arg holds an integer value    *  
                  * within the IV and UV range that can lose precision as an NV */
 
-                else if(ceil(nv_arg) == nv_arg
-                        && ((nv_arg  <  1.8446744073709552e+19 && nv_arg > 9007199254740992)
+                else if(trunc(nv_arg) == nv_arg
+                        && ((nv_arg  <  1.8446744073709552e+19 && nv_arg > 9007199254740992.0)
                              ||
-                            (nv_arg < -4503599627370496 && nv_arg  >= -9.2233720368547758e+18)) ) {
+                            (nv_arg < -9007199254740992.0 && nv_arg  >= -9.2233720368547758e+18)) ) {
 
                     int_arg = SvIV(arg);
 

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1212,8 +1212,10 @@ CODE:
             if(!SvOK(arg) || SvUOK(arg)) {
                 nv_arg = (NV)SvUV(arg);
 #ifdef UNIQ_PREC_LOSS
+
                 int_arg = SvIV(arg); /* SvIV(arg) and SvuV(arg) have the same byte structure *
                                       * and it's only the byte structure that interests us   */
+
                 if(SvUV(arg) > 9007199254740992)  /* UV to NV conversion could lose precision */
                     potential_prec_loss = 1;
 #endif
@@ -1222,7 +1224,9 @@ CODE:
             else if(SvIOK(arg)) {
                 nv_arg = (NV)SvIV(arg);
 #ifdef UNIQ_PREC_LOSS
+
                 int_arg = SvIV(arg);
+
                 if(int_arg < -4503599627370496 
                     ||
                    int_arg > 9007199254740992)  /* IV to NV conversion could lose precision */

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1216,8 +1216,7 @@ CODE:
                 int_arg = SvIV(arg); /* SvIV(arg) and SvuV(arg) have the same byte structure *
                                       * and it's only the byte structure that interests us   */
 
-                if(SvUV(arg) > 9007199254740992)  /* UV to NV conversion could lose precision */
-                    potential_prec_loss = 1;
+                potential_prec_loss = 1; /* UV to NV conversion could lose precision as SvUV(arg) > 9007199254740992 */
 #endif
             }
 
@@ -1268,16 +1267,12 @@ CODE:
 #ifdef UNIQ_PREC_LOSS
                 if(potential_prec_loss) { 
 
-                    /* Read the bytes of iv_arg into the string buffer, in hex */
+                    /* Read the bytes of int_arg into buff, in hex */
 
                     sprintf(buff, "%016" UVxf, int_arg);
                     buff += 16;
                     offset = 16;
                 }
-
-
-                /* Take appropriate action if nv_arg holds an integer value    *  
-                 * within the IV and UV range that can lose precision as an NV */
 
                 else if(trunc(nv_arg) == nv_arg
                         && ((nv_arg  <  1.8446744073709552e+19 && nv_arg > 9007199254740992.0)
@@ -1286,7 +1281,7 @@ CODE:
 
                     int_arg = SvIV(arg);
 
-                    /* Read the bytes of int_arg into the string buffer, in hex */
+                    /* Read the bytes of int_arg into buff, in hex */
 
                     sprintf(buff, "%016" UVxf, int_arg);
                     buff += 16;
@@ -1294,6 +1289,8 @@ CODE:
                 }
 
                 potential_prec_loss = 0; /* clear */
+
+                /* Read the bytes of nv_arg into buff, in hex */
 
                 for(i = 0; i < 8; i++) {
                     sprintf(buff, "%02x", ((unsigned char*)p)[i]);
@@ -1303,6 +1300,8 @@ CODE:
                 buff -= 16 + offset; /* return pointer to original position */
                 offset = 0;
 #else
+                /* Read the bytes of nv_arg into buff, in hex */
+
                 for(i = 0; i < UNIQ_LOOP_END; i++) {
                     sprintf(buff, "%02x", ((unsigned char*)p)[i]);
                     buff += 2;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,11 +7,30 @@ use File::Spec;
 use ExtUtils::MakeMaker;
 my $PERL_CORE = grep { $_ eq 'PERL_CORE=1' } @ARGV;
 
+
+my $defines = $ENV{PERL_CORE} ? q[-DPERL_EXT] : q[-DPERL_EXT -DUSE_PPPORT_H];
+
+# Determine the correct NV formatting required by uniq() in ListUtil.xs
+
+if($Config{nvsize} == 8)   {      # double or 8-byte long double
+ $defines .= " -DUNIQ_LOOP_END=8";
+ $defines .= " -DUNIQ_PREC_LOSS" if $Config{ivsize} >= 8; # precision loss is possible when
+                                                          # IV/UV is converted to NV
+}
+ 
+elsif(length(sqrt 2) > 25) {      # IEEE long double or __float128 or doubledouble
+  $defines .= " -DUNIQ_LOOP_END=16"
+}
+
+else {                            # extended precision long double (either 12-byte or 16-byte)
+  $defines .= " -DUNIQ_LOOP_END=10";  # ignore unused bytes
+}
+
 WriteMakefile(
   NAME         => q[List::Util],
   ABSTRACT     => q[Common Scalar and List utility subroutines],
   AUTHOR       => q[Graham Barr <gbarr@cpan.org>],
-  DEFINE       => ($ENV{PERL_CORE} ? q[-DPERL_EXT] : q[-DPERL_EXT -DUSE_PPPORT_H]),
+  DEFINE       => $defines,
   DISTNAME     => q[Scalar-List-Utils],
   VERSION_FROM => 'lib/List/Util.pm',
 

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -245,7 +245,7 @@ SKIP: {
 }
 
 is_deeply( [uniqnum 0, -0.0 ],
-           [0],
+           [ 0 ],
            'uniqnum handles negative zero');
 
 is_deeply( [ uniq () ],

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use Config; # to determine nvsize
-use Test::More tests => 36;
+use Test::More tests => 37;
 use List::Util qw( uniqnum uniqstr uniq );
 
 use Tie::Array;
@@ -243,6 +243,10 @@ SKIP: {
                [ 0 ],
                'uniqnum on undef coerces to zero' );
 }
+
+is_deeply( [uniqnum 0, -0.0 ],
+           [0],
+           'uniqnum handles negative zero');
 
 is_deeply( [ uniq () ],
            [],


### PR DESCRIPTION
The uniqnum() sub has some bugs that the current t/uniq.t test file fails to expose.
This pull request includes a version of t/uniq.t that has been expanded to reveal the failures of the current Scalar-List-Utils-1.52 distribution.

See https://rt.cpan.org/Public/Bug/Display.html?id=130302 for some discussion on this, and for a none-too-pretty view of the evolution of my patches.

Cheers,
Rob