### PR TITLE
increase accuracy of uniqnum

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -72,9 +72,6 @@
 #define sv_catpvn_flags(b,n,l,f) sv_catpvn(b,n,l)
 #endif
 
-#define STRINGIZE_HELPER(x) #x
-#define STRINGIZE(x) STRINGIZE_HELPER(x)
-
 /* Some platforms have strict exports. And before 5.7.3 cxinc (or Perl_cxinc)
    was not exported. Therefore platforms like win32, VMS etc have problems
    so we redefine it here -- GMB
@@ -1245,7 +1242,7 @@ CODE:
                 /* smaller floats get formatted using %g and could be equal to
                  * a UV or IV */
                 else {
-                    sv_setpvf(keysv, "%0." STRINGIZE(NV_MAX_PRECISION) NVgf, nv_arg);
+                    sv_setpvf(keysv, "%0.*" NVgf, NV_MAX_PRECISION, nv_arg);
                 }
             }
 #ifdef HV_FETCH_EMPTY_HE

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1235,9 +1235,11 @@ CODE:
                     sv_setpvf(keysv, "%" NVgf, nv_arg);
                 }
                 /* for numbers outside of the IV or UV range, we don't need to
-                 * use a comparable format, so just use the raw bytes */
+                 * use a comparable format, so just use the raw bytes, adding
+                 * 'f' to ensure not matching a stringified number */
                 else if (nv_arg < (NV)IV_MIN || nv_arg > (NV)UV_MAX) {
                     sv_setpvn(keysv, (char *) &nv_arg, sizeof(NV));
+                    sv_catpvn(keysv, "f", 1);
                 }
                 /* smaller floats get formatted using %g and could be equal to
                  * a UV or IV */

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,12 +6,42 @@ use Config;
 use File::Spec;
 use ExtUtils::MakeMaker;
 my $PERL_CORE = grep { $_ eq 'PERL_CORE=1' } @ARGV;
+my $defines = $ENV{PERL_CORE} ? q[-DPERL_EXT] : q[-DPERL_EXT -DUSE_PPPORT_H];
+
+my $nv_digits;
+
+my $ivsize = $Config{ivsize} * 8;
+my $uv_digits = 1 + int(log(2) / log(10) * $ivsize);
+
+my $nvsize = $Config{nvsize} * 8;
+# we want NV and UV numbers in the same range to format the same, so make sure
+# NVs are given at least as many digits as UVs.  If IV/UVs have equal or
+# greater bits, there's no reason to check NV size since it won't be able to
+# have as much mantissa.
+if ($ivsize >= $nvsize) {
+  $nv_digits = $uv_digits;
+}
+else {
+  # maximum possible digits that could fit in something NV size
+  my $max_digits = 1 + int(log(2) / log(10) * $nvsize);
+
+  my $float = sprintf '%0.'.$max_digits.'g', 1/9;
+  my ($accurate_digits) = $float =~ /(1+)/;
+  # additional digit provides 'partial' accuracy
+  $nv_digits = 1 + length $accurate_digits;
+
+  if ($nv_digits < $uv_digits) {
+    $nv_digits = $uv_digits;
+  }
+}
+
+$defines .= " -DNV_MAX_PRECISION=$nv_digits";
 
 WriteMakefile(
   NAME         => q[List::Util],
   ABSTRACT     => q[Common Scalar and List utility subroutines],
   AUTHOR       => q[Graham Barr <gbarr@cpan.org>],
-  DEFINE       => ($ENV{PERL_CORE} ? q[-DPERL_EXT] : q[-DPERL_EXT -DUSE_PPPORT_H]),
+  DEFINE       => $defines,
   DISTNAME     => q[Scalar-List-Utils],
   VERSION_FROM => 'lib/List/Util.pm',
 

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -207,7 +207,22 @@ SKIP: {
     my $maxint = ~0 >> 1;
     my $minint = -(~0 >> 1) - 1;
 
-    my @nums = ($maxuint, $maxuint-1, -1, $Inf, $NaN, $maxint, $minint, 1 );
+    my @nums = ($maxuint, $maxuint-1, -1, $maxint, $minint, 1 );
+
+    {
+        use warnings FATAL => 'numeric';
+        if (eval {
+            "$Inf" + 0 == $Inf
+        }) {
+            push @nums, $Inf;
+        }
+        if (eval {
+            my $nanish = "$NaN" + 0;
+            $nanish != 0 && !$nanish != $NaN;
+        }) {
+            push @nums, $NaN;
+        }
+    }
 
     is_deeply( [ uniqnum @nums, 1.0 ],
                [ @nums ],
@@ -218,10 +233,6 @@ SKIP: {
     if($maxuint !~ /\A[0-9]+\z/) {
       skip( "Perl $] doesn't stringify UV_MAX right ($maxuint)", 1 );
     }
-    elsif($] < 5.022 && $^O =~ /MSWin32/i) {
-      skip( "On MS Windows,perl $] stringifies infs and nans into something unusable", 1 );
-    }
-
 
     is_deeply( [ uniqnum @strs, "1.0" ],
                [ @strs ],

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use Config; # to determine nvsize
-use Test::More tests => 38;
+use Test::More tests => 39;
 use List::Util qw( uniqnum uniqstr uniq );
 
 use Tie::Array;
@@ -237,6 +237,13 @@ SKIP: {
     is_deeply( [ uniqnum @strs, "1.0" ],
                [ @strs ],
                'uniqnum preserves uniqueness of full integer range (stringified)' );
+}
+
+{
+    my @nums = (6.82132005170133e-38, 62345678);
+    is_deeply( [ uniqnum @nums ], [ @nums ],
+        'uniqnum keeps uniqueness of numbers that stringify to the same byte pattern as a float'
+    );
 }
 
 {

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -148,13 +148,13 @@ else {
 }
 
 if($equiv) {
-  is($uniq_count1, 1, 'uniqnum preserves uniqness of high precision floats');
-  is($uniq_count2, 1, 'uniqnum preserves uniqness of high precision floats (stringified)');
+  is($uniq_count1, 1, 'uniqnum preserves uniqueness of high precision floats');
+  is($uniq_count2, 1, 'uniqnum preserves uniqueness of high precision floats (stringified)');
 }
 
 else {
-  is($uniq_count1, 2, 'uniqnum preserves uniqness of high precision floats');
-  is($uniq_count2, 2, 'uniqnum preserves uniqness of high precision floats (stringified)');
+  is($uniq_count1, 2, 'uniqnum preserves uniqueness of high precision floats');
+  is($uniq_count2, 2, 'uniqnum preserves uniqueness of high precision floats (stringified)');
 }
 
 SKIP: {
@@ -226,7 +226,7 @@ SKIP: {
 
     is_deeply( [ uniqnum @nums, 1.0 ],
                [ @nums ],
-               'uniqnum preserves uniqness of full integer range' );
+               'uniqnum preserves uniqueness of full integer range' );
 
     my @strs = map "$_", @nums;
 
@@ -236,7 +236,7 @@ SKIP: {
 
     is_deeply( [ uniqnum @strs, "1.0" ],
                [ @strs ],
-               'uniqnum preserves uniqness of full integer range (stringified)' );
+               'uniqnum preserves uniqueness of full integer range (stringified)' );
 }
 
 {

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -6,6 +6,11 @@ use Config; # to determine nvsize
 use Test::More tests => 38;
 use List::Util qw( uniqnum uniqstr uniq );
 
+# The following information could be useful in diagnosing failures.
+# (Print it to STDERR so that the info shows up in smoker reports.)
+
+warn "\nFYI:\n\$Config{d_Gconvert} is '$Config{d_Gconvert}'\n\n";
+
 use Tie::Array;
 
 is_deeply( [ uniqstr ],

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -2,8 +2,8 @@
 
 use strict;
 use warnings;
-
-use Test::More tests => 33;
+use Config; # to determine nvsize
+use Test::More tests => 38;
 use List::Util qw( uniqnum uniqstr uniq );
 
 use Tie::Array;
@@ -87,6 +87,112 @@ is_deeply( [ uniqnum qw( 1 1.1 1.2 1.3 ) ],
                'uniqnum distinguishes large floats (stringified)' );
 }
 
+my ($uniq_count1, $uniq_count2, $equiv);
+
+if($Config{nvsize} == 8) {
+  # NV is either 'double' or 8-byte 'long double'
+
+  # The 2 values should be unequal - but just in case perl is buggy:
+  $equiv = 1 if 1.4142135623730951 == 1.4142135623730954;
+
+  $uniq_count1 = List::Util::uniqnum (1.4142135623730951,
+                                        1.4142135623730954 );
+
+  $uniq_count2 = List::Util::uniqnum('1.4142135623730951',
+                                       '1.4142135623730954' );
+}
+
+elsif(length(sqrt(2)) > 25) {
+  # NV is either IEEE 'long double' or '__float128' or doubledouble
+
+  if(1 + (2 ** -1074) != 1) {
+    # NV is doubledouble
+
+    # The 2 values should be unequal - but just in case perl is buggy:
+    $equiv = 1 if 1 + (2 ** -1074) == 1 + (2 ** - 1073);
+
+    $uniq_count1 = List::Util::uniqnum (1 + (2 ** -1074),
+                                        1 + (2 ** -1073) );
+    # The 2 values should be unequal - but just in case perl is buggy:
+    $equiv = 1 if 4.0564819207303340847894502572035e31 == 4.0564819207303340847894502572034e31;
+
+    $uniq_count2 = List::Util::uniqnum('4.0564819207303340847894502572035e31',
+                                       '4.0564819207303340847894502572034e31' );
+  }
+
+  else {
+    # NV is either IEEE 'long double' or '__float128'
+
+    # The 2 values should be unequal - but just in case perl is buggy:
+    $equiv = 1 if 1.7320508075688772935274463415058722 == 1.73205080756887729352744634150587224;
+
+    $uniq_count1 = List::Util::uniqnum (1.7320508075688772935274463415058722,
+                                        1.73205080756887729352744634150587224 );
+
+    $uniq_count2 = List::Util::uniqnum('1.7320508075688772935274463415058722',
+                                       '1.73205080756887729352744634150587224' );
+  }
+}
+
+else {
+  # NV is extended precision 'long double'
+
+  # The 2 values should be unequal - but just in case perl is buggy:
+  $equiv = 1 if 2.2360679774997896963 == 2.23606797749978969634;
+
+  $uniq_count1 = List::Util::uniqnum (2.2360679774997896963,
+                                      2.23606797749978969634 );
+
+  $uniq_count2 = List::Util::uniqnum('2.2360679774997896963',
+                                     '2.23606797749978969634' );
+}
+
+if($equiv) {
+  is($uniq_count1, 1, 'uniqnum preserves uniqness of high precision floats');
+  is($uniq_count2, 1, 'uniqnum preserves uniqness of high precision floats (stringified)');
+}
+
+else {
+  is($uniq_count1, 2, 'uniqnum preserves uniqness of high precision floats');
+  is($uniq_count2, 2, 'uniqnum preserves uniqness of high precision floats (stringified)');
+}
+
+SKIP: {
+    skip ('test not relevant for this perl configuration', 1) unless $Config{nvsize} == 8
+                                                                  && $Config{ivsize} == 8;
+
+    my @in = (~0, ~0 - 1, 18446744073709551614.0, 18014398509481985, 1.8014398509481985e16);
+    my(@correct);
+
+    # On perl-5.6.2 (and perhaps other old versions), ~0 - 1 is assigned to an NV.
+    # This affects the outcome of the following test, so we need to first determine
+    # whether ~0 - 1 is an NV or a UV:
+
+    if("$in[1]" eq "1.84467440737096e+19") {
+
+      # It's an NV and $in[2] is a duplicate of $in[1]
+      @correct = (~0, ~0 - 1, 18014398509481985, 1.8014398509481985e16);
+    }
+    else {
+
+      # No duplicates in @in
+      @correct = @in;
+    }
+
+    is_deeply( [ uniqnum @in ],
+               [ @correct ],
+               'uniqnum correctly compares UV/IVs that overflow NVs' );
+}
+
+my $ls = 31;
+if($Config{ivsize} == 8) { $ls = 63 }
+
+is_deeply( [ uniqnum ( 1 << $ls, 2 ** $ls,
+                       1 << ($ls - 3), 2 ** ($ls - 3),
+                       5 << ($ls - 3), 5 * (2 ** ($ls - 3))) ],
+           [ 1 << $ls, 1 << ($ls - 3), 5 << ($ls -3) ],
+           'uniqnum correctly compares UV/IVs that don\'t overflow NVs' );
+
 # Hard to know for sure what an Inf is going to be. Lets make one
 my $Inf = 0 + 1E1000;
 my $NaN;
@@ -109,8 +215,13 @@ SKIP: {
 
     my @strs = map "$_", @nums;
 
-    skip( "Perl $] doesn't stringify UV_MAX right ($maxuint)", 1 )
-        if $maxuint !~ /\A[0-9]+\z/;
+    if($maxuint !~ /\A[0-9]+\z/) {
+      skip( "Perl $] doesn't stringify UV_MAX right ($maxuint)", 1 );
+    }
+    elsif($] < 5.022 && $^O =~ /MSWin32/i) {
+      skip( "On MS Windows,perl $] stringifies infs and nans into something unusable", 1 );
+    }
+
 
     is_deeply( [ uniqnum @strs, "1.0" ],
                [ @strs ],
@@ -131,6 +242,10 @@ SKIP: {
                [ 0 ],
                'uniqnum on undef coerces to zero' );
 }
+
+is_deeply( [uniqnum 0, -0.0 ],
+           [0],
+           'uniqnum handles negative zero');
 
 is_deeply( [ uniq () ],
            [],

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -6,11 +6,6 @@ use Config; # to determine nvsize
 use Test::More tests => 38;
 use List::Util qw( uniqnum uniqstr uniq );
 
-# The following information could be useful in diagnosing failures.
-# (Print it to STDERR so that the info shows up in smoker reports.)
-
-warn "\nFYI:\n\$Config{d_Gconvert} is '$Config{d_Gconvert}'\n\n";
-
 use Tie::Array;
 
 is_deeply( [ uniqstr ],

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -95,11 +95,11 @@ if($Config{nvsize} == 8) {
   # The 2 values should be unequal - but just in case perl is buggy:
   $equiv = 1 if 1.4142135623730951 == 1.4142135623730954;
 
-  $uniq_count1 = List::Util::uniqnum (1.4142135623730951,
-                                        1.4142135623730954 );
+  $uniq_count1 = uniqnum (1.4142135623730951,
+                          1.4142135623730954 );
 
-  $uniq_count2 = List::Util::uniqnum('1.4142135623730951',
-                                       '1.4142135623730954' );
+  $uniq_count2 = uniqnum('1.4142135623730951',
+                         '1.4142135623730954' );
 }
 
 elsif(length(sqrt(2)) > 25) {
@@ -111,13 +111,13 @@ elsif(length(sqrt(2)) > 25) {
     # The 2 values should be unequal - but just in case perl is buggy:
     $equiv = 1 if 1 + (2 ** -1074) == 1 + (2 ** - 1073);
 
-    $uniq_count1 = List::Util::uniqnum (1 + (2 ** -1074),
-                                        1 + (2 ** -1073) );
+    $uniq_count1 = uniqnum (1 + (2 ** -1074),
+                            1 + (2 ** -1073) );
     # The 2 values should be unequal - but just in case perl is buggy:
     $equiv = 1 if 4.0564819207303340847894502572035e31 == 4.0564819207303340847894502572034e31;
 
-    $uniq_count2 = List::Util::uniqnum('4.0564819207303340847894502572035e31',
-                                       '4.0564819207303340847894502572034e31' );
+    $uniq_count2 = uniqnum('4.0564819207303340847894502572035e31',
+                           '4.0564819207303340847894502572034e31' );
   }
 
   else {
@@ -126,11 +126,11 @@ elsif(length(sqrt(2)) > 25) {
     # The 2 values should be unequal - but just in case perl is buggy:
     $equiv = 1 if 1.7320508075688772935274463415058722 == 1.73205080756887729352744634150587224;
 
-    $uniq_count1 = List::Util::uniqnum (1.7320508075688772935274463415058722,
-                                        1.73205080756887729352744634150587224 );
+    $uniq_count1 = uniqnum (1.7320508075688772935274463415058722,
+                            1.73205080756887729352744634150587224 );
 
-    $uniq_count2 = List::Util::uniqnum('1.7320508075688772935274463415058722',
-                                       '1.73205080756887729352744634150587224' );
+    $uniq_count2 = uniqnum('1.7320508075688772935274463415058722',
+                           '1.73205080756887729352744634150587224' );
   }
 }
 
@@ -140,11 +140,11 @@ else {
   # The 2 values should be unequal - but just in case perl is buggy:
   $equiv = 1 if 2.2360679774997896963 == 2.23606797749978969634;
 
-  $uniq_count1 = List::Util::uniqnum (2.2360679774997896963,
-                                      2.23606797749978969634 );
+  $uniq_count1 = uniqnum (2.2360679774997896963,
+                          2.23606797749978969634 );
 
-  $uniq_count2 = List::Util::uniqnum('2.2360679774997896963',
-                                     '2.23606797749978969634' );
+  $uniq_count2 = uniqnum('2.2360679774997896963',
+                         '2.23606797749978969634' );
 }
 
 if($equiv) {


### PR DESCRIPTION
Using sprintf "%.15g" as the value to compare does not maintain the full
accuracy of floating point numbers.  Rather than 15, use a precision
value based on the accuracy the current platform can represent.

Also add some special cases: treat 0 and -0.0 as equivalent, and NaNs
are compared based on the platform's stringification of them.

Additionally, sprintf may not be able to accurately represent some
floating point numbers, no matter how many digits are given.  If the
numbers are outside the IV/UV range, they don't need to be compared to
anything other than other floats, so we can use a totally different
format for the unique string.  Use their raw bytes, as this is the
easiest and fastest.

Fixes RT#130935, RT#130302, RT#130277