### PR TITLE
avoid done_testing for compatibility with old perl

### DIFF
--- a/t/reductions.t
+++ b/t/reductions.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More;
+use Test::More tests => 7;
 
 use List::Util qw( reductions );
 
@@ -49,5 +49,3 @@ sub Guardian::DESTROY { $destroyed_count++ }
 
   is( $destroyed_count, 2, 'intermediate temporaries are destroyed after exception' );
 }
-
-done_testing;

--- a/t/sample.t
+++ b/t/sample.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More;
+use Test::More tests => 9;
 
 use List::Util qw(sample);
 
@@ -69,5 +69,3 @@ use List::Util qw(sample);
     'rigged rand() yields predictable output'
   );
 }
-
-done_testing;


### PR DESCRIPTION
done_testing was added in Test::More 0.88, and isn't available on stock
perls older than 5.10.1.  Adding a dependency on a newer Test::More
would introduce a dependency loop on those older perls.