### PR TITLE
test predictable $RAND giving consistent results, not predefined results

### DIFF
--- a/t/sample.t
+++ b/t/sample.t
@@ -65,7 +65,9 @@ use List::Util qw(sample);
 {
   local $List::Util::RAND = sub { 4/10 };
 
-  is( join( "", sample 5, 'A'..'Z' ), 'JKALC',
+  is(
+    join( "", sample 5, 'A'..'Z' ),
+    join( "", sample 5, 'A'..'Z' ),
     'rigged rand() yields predictable output'
   );
 }

--- a/t/shuffle.t
+++ b/t/shuffle.t
@@ -29,8 +29,9 @@ is( "@in",	"@s",	'values');
   local $List::Util::RAND = sub { 4/10 }; # chosen by a fair die
 
   @r = shuffle(1..10);
-  # This random function happens to always generate the same result
-  is_deeply( \@r, [ 10, 1, 8, 2, 6, 7, 3, 9, 4, 5 ],
+  is_deeply(
+    [ shuffle(1..10) ],
+    [ shuffle(1..10) ],
     'rigged rand() yields predictable output'
   );
 }


### PR DESCRIPTION
Rather than testing the output of shuffle or sample with a predictable
$RAND resulting in a specific pattern, run the function multiple times
and verify it gives the same results.  This means the test doesn't have
to rely on the specific implementation of the functions, since there are
many ways they could be written.  Users also shouldn't be relying on a
given random function giving identical results across versions or
systems.