### PR TITLE
avoid using Scalar::Util functions in List::Util tests

### DIFF
--- a/t/pair.t
+++ b/t/pair.t
@@ -5,7 +5,6 @@ use warnings;
 
 use Test::More tests => 29;
 use List::Util qw(pairgrep pairfirst pairmap pairs unpairs pairkeys pairvalues);
-use Scalar::Util qw(blessed);
 
 no warnings 'misc'; # avoid "Odd number of elements" warnings most of the time
 
@@ -108,7 +107,7 @@ is_deeply( [ pairs one => 1, two => ],
   is_deeply( $p[0]->TO_JSON,
              [ one => 1 ],
              'pairs ->TO_JSON' );
-  ok( !blessed($p[0]->TO_JSON) , 'pairs ->TO_JSON is not blessed' );
+  is( ref($p[0]->TO_JSON), 'ARRAY', 'pairs ->TO_JSON is not blessed' );
 }
 
 is_deeply( [ unpairs [ four => 4 ], [ five => 5 ], [ six => 6 ] ],


### PR DESCRIPTION
This ensures that changes to one won't impact the test for the other.
It also prepares for a potential future where the modules are split into
separate dists.  This also makes it easier to port tests to
List::Util::PP, which wants to avoid all direct dependencies on
Scalar::Util.

This change is admittedly mainly to make it easier for me to maintain List::Util::PP.