### PR TITLE
Fix uniqnum for mingw-built Win32 perls that don't define __USE_MINGW_ANSI_STDIO

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,12 +21,6 @@ elsif( $Config{nvsize} == 8 ) { $nv_digits = 17 } # POSIX::ceil(1 + (log(2) / lo
 elsif( length(sqrt 2) < 30 )  { $nv_digits = 21 } # POSIX::ceil(1 + (log(2) / log(10) *  64))
 else                          { $nv_digits = 36 } # POSIX::ceil(1 + (log(2) / log(10) * 113))
 
-print "\nDIGITS: $nv_digits\n";
-die "WRONG" if $nv_digits == 20 && $Config{nvsize} != $Config{ivsize};
-die "WRONG" if $nv_digits == 17 && $Config{nvsize} != 8;
-die "WRONG" if $nv_digits == 21 && $Config{nvtype} ne 'long double';
-die "WRONG" if $nv_digits == 36 && $Config{nvtype} ne '__float128';
-
 $defines .= " -DNV_MAX_PRECISION=$nv_digits";
 
 WriteMakefile(


### PR DESCRIPTION
First up:
The changes I've made to the Makefile.PL have nothing to do with this topic.
They simply remove stuff that I never intended to be included in https://github.com/Dual-Life/Scalar-List-Utils/pull/91
That "stuff" was really only relevant to my own systems and was there as an additional check that some brainfart of mine was not setting NV_MAX_PRECISION greater than necessary - which is something that the test suite would not detect. (Should the test suite check be checking for this ?)

I'm quite happy to reinstate that "stuff" if it's requested, though there would then need to be some modification of it.
For example, whilst it's true, on my machines, that an NV_MAX_PRECISION value of 36 implies an nvtype of __float128, there are some architectures where the value of 36 would imply nvtype of 'long double'.

Moving on to this issue:
On MinGW-built perls, "%0.20g" formatting breaks down with integer values that comprise more than 17 digits, unless perl was built with -D__USE_MINGW_ANSI_STDIO.
The breakage is that the values are merely rounded to 17 digits, with the appropriate number of  zeroes being appended.
We rely on correct formatting in the ListUtil.xs at the line:
\====================================
sv_setpvf(keysv, "%0.*" NVgf, NV_MAX_PRECISION, nv_arg);
\====================================

which is ok if NV_MAX_PRECISION is 17, but not if it's 20.

To fix this, we define __USE_MINGW_ANSI_STDIO to 1 at the beginning of ListUtil.xs.
But, when NV_MAX_PRECISION is 20, we still can't reliably do:
\====================================
sv_setpvf(keysv, "%0.*" NVgf, NV_MAX_PRECISION, nv_arg);
\====================================
(For that to work reliably, perl would need to have been built with -D__USE_LONG_DOUBLE, but the ship has already sailed.)

What we can do, however, is:
\========================
char buffer[32];
 sprintf(buffer, "%0.20" NVgf, nv_arg);
 sv_setpvf(keysv, "%s", buffer);
\========================

Because we've defined the symbol at the beginning of ListUtil.xs, we have enabled
sprintf(buffer, "%0.20" NVgf, nv_arg);
to work reliably.

And that will fix the issue leading to the 3 FAIL reports for SLU-1.54 at:
https://www.cpantesters.org/cpan/report/8bba3592-6c01-1014-8853-a0eecb767d31
https://www.cpantesters.org/cpan/report/01320fb5-6bfc-1014-b37d-5cf9427e260b
https://www.cpantesters.org/cpan/report/ab9847cb-6bf8-1014-930c-34d15fe45038

NOTE:
I've declared "char buffer[32]", although I can't think of a case that would require more than 28 chars.
Do we want to reduce the "32" to a lower value ?

Cheers,
Rob


