### PR TITLE
Improve uniqnum's handling of configurations where IVSIZE != NVSIZE

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1349,7 +1349,11 @@ CODE:
                 SvNV(arg); /* SvIV() sets SVf_IOK even on floats on 5.6 */
 #endif
             }
-#if IVSIZE != NVSIZE  /* open nvsize!=ivsize block */
+#if NVSIZE > IVSIZE  /* open nvsize>ivsize block */
+
+        /* We can detect duplicates by looking *
+         * solely at the value of SvNV(arg)    */
+              
         nv_arg = SvNV(arg);
 
         if(nv_arg == 0) {
@@ -1364,7 +1368,11 @@ CODE:
             /* Use the byte structure of the NV. */
             sv_setpvn(keysv, (char *) &nv_arg, sizeof(NV));  
         }
-#else                 /* close ivsize!=nvsize block, open ivsize==nvsize block */
+#else                 /* close nvsize>ivsize block, open ivsize==nvsize block */
+
+            /* Because IVSIZE == NVSIZE we cannot rely *
+             * solely on the value of SvNV(arg)        */
+
             if(!SvOK(arg) || SvUOK(arg)) {
                 sv_setpvf(keysv, "%" UVuf, SvUV(arg));
             }

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,21 +8,6 @@ use ExtUtils::MakeMaker;
 my $PERL_CORE = grep { $_ eq 'PERL_CORE=1' } @ARGV;
 my $defines = $ENV{PERL_CORE} ? q[-DPERL_EXT] : q[-DPERL_EXT -DUSE_PPPORT_H];
 
-my $nv_digits;
-
-# Generally NV_MAX_PRECISION needs to be set to ceil(1 + (log 2 / log(10) * prec))
-# where prec is the bit-precision of the NV's mantissa, including any implied bits.
-# However, if nvsize <= ivsize NV_MAX_PRECISION needs to be set to the length
-# of UV_MAX (where UV_MAX is the UV with the greatest magnitude).
-
-if( $Config{nvsize} <=
-    $Config{ivsize} )         { $nv_digits = 20 } # length(~0) 
-elsif( $Config{nvsize} == 8 ) { $nv_digits = 17 } # POSIX::ceil(1 + (log(2) / log(10) *  53))
-elsif( length(sqrt 2) < 30 )  { $nv_digits = 21 } # POSIX::ceil(1 + (log(2) / log(10) *  64))
-else                          { $nv_digits = 36 } # POSIX::ceil(1 + (log(2) / log(10) * 113))
-
-$defines .= " -DNV_MAX_PRECISION=$nv_digits";
-
 my %params = (
   NAME         => q[List::Util],
   ABSTRACT     => q[Common Scalar and List utility subroutines],


### PR DESCRIPTION
In ListUtil.xs, I inserted an "#if IVSIZE != NVSIZE" block into uniqnum().
That block is needed for the case where NV is doubledouble - but it so happens that all other configurations where IVSIZE != NVSIZE" are handled more efficiently by that same approach.
Therefore, rather than create that block as "#ifdef NV_IS_DOUBLEDOUBLE",  I've expanded it to handle all cases where IVSIZE != NVSIZE.
At the end of this post, I'll include the benchmark script which (hopefully) demonstrates the benefit of this approach.

Having done that, it then meant that the one occurrence of NV_MAX_PRECISION was always 20.
Hence, we're able to replace that occurrence of NV_MAX_PRECISION with a hard-coded "20", and remove the calculations of NV_MAX_PRECISION from the Makefile.PL.

I suppose one annoyance with this is that there are 2 different paths we can take in uniqnum that result in performing essentially the same procedure of check for 0, check fr NaN, read the bytes into keysv.
The first place is  in the "#if IVSIZE != NVSIZE" block,
The second place is in a section of the accompanying "#else" block.

I'm not sure whether that doubling up can be eliminated - something to look at next, perhaps.
For the moment, I just wanted to keep the logic set out as clearly as possible.

Here's the benchmark comparison script I used:

\=============================
use warnings;
use Benchmark;
use Inline C => <<'EOC';

void as_iv (SV * in, ...) {
  dXSARGS;
  int i;
  SV *keysv = sv_newmortal();

  for(i = 0; i < items; i++) {
    if(!SvOK(ST(i)) || SvUOK(ST(i))) {
      sv_setpvf(keysv, "%" UVuf, SvUV(ST(i)));
    }
    else if(SvIOK(ST(i))) {
      sv_setpvf(keysv, "%" IVdf, SvIV(ST(i)));
    }
    else {
      croak("Should not have got to here");
    }
  }
}

void as_nv(SV * in, ...) {
  dXSARGS;
  int i;
  NV nv_arg;
  SV *keysv = sv_newmortal();

  for(i = 0; i < items; i++) {
    nv_arg = SvNV(ST(i));

    if(nv_arg == 0) {
      sv_setpvs(keysv, "0");
    }
    else if (nv_arg != nv_arg) {
      sv_setpvf(keysv, "%" NVgf, nv_arg);
    }
    else {
      sv_setpvn(keysv, (char *) &nv_arg, sizeof(NV));
    }
  }  
}

EOC

my @uv;
my $iv_high = ~0 >> 1;
my $iv_low  = $iv_high - 90000;


for($iv_low .. $iv_high) { push @uv, $_ << 1; }

@iv = (1 .. 100000, 900000 .. 1000000,
       100000000 .. 100090000,
       1000000000 .. 1000090000, @uv);

print scalar @iv, "\n";

die "Input array not as expected" unless @iv == 470004;

timethese (1, {
  'AS_IV' => 'as_iv(@iv);',
  'AS_NV' => 'as_nv(@iv);',
});
\=============================

The output for my -Duselongdouble build of perl on Windows is:

Benchmark: timing 1 iterations of AS_IV, AS_NV...
     AS_IV:  0 wallclock secs ( 0.08 usr +  0.00 sys =  0.08 CPU) @ 12.82/s (n=1)
            (warning: too few iterations for a reliable count)
     AS_NV:  0 wallclock secs ( 0.02 usr +  0.01 sys =  0.03 CPU) @ 32.26/s (n=1)
            (warning: too few iterations for a reliable count)

Irrespective of the configuration of perl, that script always claims that as_nv() is at least twice as fast as as_iv().

I don't think I've skewed the testing in favour of one approach over the other.

I'll just repeat that distinguishing doubledoubles on the basis of stringified values is unworkable. For doubledoubles we really do need to look at the byte structure.
(More than happy to elaborate on that, if requested.)

I presume travis will check the IVSIZE==NVSIZE configuration thoroughly.
I have tested most of the IVSIZE!=NVSIZE configurations - including nvtypes of 80-bit long double and __float128 on my local windows and linux systems.
I've also tested the case where IVSIZE is 4 && NVSIZE is 8.
And, of course, I've tested the doubledouble.

Cheers,
Rob
