### PR TITLE
ListUtil.xs: silence signed/unsigned build warning in List::Util::sample()

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -22,6 +22,7 @@
 #include <EXTERN.h>
 #include <perl.h>
 #include <XSUB.h>
+#include <math.h>
 
 #ifdef USE_PPPORT_H
 #  define NEED_sv_2pv_flags 1

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1261,8 +1261,8 @@ sample(...)
 PROTOTYPE: $@
 CODE:
 {
-    UV count = items ? SvUV(ST(0)) : 0;
-    int reti = 0;
+    IV count = items ? SvUV(ST(0)) : 0;
+    IV reti = 0;
     SV *randsv = get_sv("List::Util::RAND", 0);
     CV * const randcv = randsv && SvROK(randsv) && SvTYPE(SvRV(randsv)) == SVt_PVCV ?
         (CV *)SvRV(randsv) : NULL;


### PR DESCRIPTION
"items" from dXSVARS is an I32. Defining count to be 'UV' means
we get warnings about signed/unsigned comparisons, further, reti
is defined as "int" which /could/ be as little as 16 bits, and also
throws signed/unsigned warnings when compared to count.

This patch defines both count and reti to be IV's.

Eg:
    ListUtil.xs: In function ‘XS_List__Util_sample’:
    ListUtil.xs:1263:14: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
	 if(count > items)
		  ^
    ListUtil.xs:1272:16: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
	 while(reti < count) {
		    ^