### PR TITLE
Fix uniqnum for less recent Microsoft Compilers

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1349,7 +1349,10 @@ CODE:
 #endif
             }
 #if NVSIZE > IVSIZE                          /* $Config{nvsize} > $Config{ivsize} */
-        nv_arg = SvNV(arg);
+        /* Avoid altering arg's flags */ 
+        if(SvUOK(arg))      nv_arg = (NV)SvUV(arg);
+        else if(SvIOK(arg)) nv_arg = (NV)SvIV(arg);
+        else                nv_arg = SvNV(arg);
 
         /* use 0 for all zeros */
         if(nv_arg == 0) sv_setpvs(keysv, "0");
@@ -1411,7 +1414,8 @@ CODE:
                  * is untrue. However, if (iv < 0 && !SvUOK(arg)) we need to multiply iv *
                  * by -1 prior to performing that '&' operation - so multiply iv by sign.*/
                 if( !((iv * sign) & (~valid_bits)) ) {
-                    nv_arg = SvNV(arg);
+                    /* Avoid altering arg's flags */
+                    nv_arg = uok ? (NV)SvUV(arg) : (NV)SvIV(arg); 
                     sv_setpvn(keysv, (char *) &nv_arg, 8);
                 }          
                 else {

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1379,10 +1379,10 @@ CODE:
 #else                                    /* $Config{nvsize} == $Config{ivsize} == 8 */ 
         if( SvIOK(arg) || !SvOK(arg) ) {
 
-           /* It doesn't matter if SvUOK(arg) is TRUE */
+            /* It doesn't matter if SvUOK(arg) is TRUE */
             IV iv = SvIV(arg);
 
-           /* use "0" for all zeros */
+            /* use "0" for all zeros */
             if(iv == 0) sv_setpvs(keysv, "0");
 
             else {

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -198,10 +198,6 @@ my @in = (1 << $ls, 2 ** $ls,
           1 << ($ls - 3), 2 ** ($ls - 3),
           5 << ($ls - 3), 5 * (2 ** ($ls - 3)));
 
-use Devel::Peek;
-Dump $in[0];
-Dump $in[1];
-
 my @correct = (1 << $ls, 1 << ($ls - 3), 5 << ($ls -3));
 
 if( $Config{ivsize} == 8 && $Config{nvsize} == 8 ) {
@@ -339,11 +335,6 @@ SKIP: {
   # 99999999999999984 is the largest 64-bit integer less than 1e17
   # that can be expressed exactly as a double
 
-  my $t1 = 99999999999999984;
-  Dump $t1;
-  my $t2 = 99999999999999984.0;
-  Dump $t2;
-
   is_deeply( [ uniqnum (99999999999999984, 99999999999999984.0) ],
              [ (99999999999999984) ],
              'uniqnum recognizes 99999999999999984 and 99999999999999984.0 as the same' );
@@ -354,11 +345,6 @@ SKIP: {
 
   # 100000000000000016 is the smallest positive 64-bit integer greater than 1e17
   # that can be expressed exactly as a double
-
-  my $t3 = 100000000000000016;
-  Dump $t3;
-  my $t4 = 100000000000000016.0;
-  Dump $t4;
 
   is_deeply( [ uniqnum (100000000000000016, 100000000000000016.0) ],
              [ (100000000000000016) ],

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -198,6 +198,10 @@ my @in = (1 << $ls, 2 ** $ls,
           1 << ($ls - 3), 2 ** ($ls - 3),
           5 << ($ls - 3), 5 * (2 ** ($ls - 3)));
 
+use Devel::Peek;
+Dump $in[0];
+Dump $in[1];
+
 my @correct = (1 << $ls, 1 << ($ls - 3), 5 << ($ls -3));
 
 if( $Config{ivsize} == 8 && $Config{nvsize} == 8 ) {
@@ -335,6 +339,11 @@ SKIP: {
   # 99999999999999984 is the largest 64-bit integer less than 1e17
   # that can be expressed exactly as a double
 
+  my $t1 = 99999999999999984;
+  Dump $t1;
+  my $t2 = 99999999999999984.0;
+  Dump $t2;
+
   is_deeply( [ uniqnum (99999999999999984, 99999999999999984.0) ],
              [ (99999999999999984) ],
              'uniqnum recognizes 99999999999999984 and 99999999999999984.0 as the same' );
@@ -345,6 +354,11 @@ SKIP: {
 
   # 100000000000000016 is the smallest positive 64-bit integer greater than 1e17
   # that can be expressed exactly as a double
+
+  my $t3 = 100000000000000016;
+  Dump $t3;
+  my $t4 = 100000000000000016.0;
+  Dump $t4;
 
   is_deeply( [ uniqnum (100000000000000016, 100000000000000016.0) ],
              [ (100000000000000016) ],


### PR DESCRIPTION
Also fixes a problem I came across with DoubleDouble NV types.
The problem was, that with this NV type, the DoubleDouble pair (x, 0.0) would be considered distinct from the DoubleDouble pair (x, -0.0).
Clearly, they should be regarded as duplicates of each other because x + 0.0 == x - 0.0 for all non-NaN x.

The main fix, however, is for perls whose nvsize == ivsize == 8 that were built with older MS compilers like VC++ 2010 (aka Visual C++ 10.0, among other things).
This was the issue that for many large IV/UV values that could also be exactly represented by an NV,
the NV and the IV/UV were not being recognized as duplicates of each other.

To fix it, I was forced to a solution that turned out to be so elegant and efficient, that I applied it "across the board" for all perls whose nvsize == ivsize == 8.

I'm not sure if this PR forum allows one to see what the uniqnum function in it's proposed form will actually look like.
I'm guessing it does, but if not, feel free to take a look at the uniqnum() implementation in https://fastapi.metacpan.org/source/SISYPHUS/List-Uniqnum-0.08/Uniqnum.xs as it should be identical to the uniqnum implementation proposed here - save for some small differences in comments.
(That implementation of Uniqnum.xs is passing all tests. There is just the one UNKNOWN result which presumably relates to the brokenness of that particular Strawberry Perl smoker, as I strike no such problem with the exact same build of Strawberry Perl.)

That's about it ... comments and questions welcome ... now it's time to find out what Travis thinks about this ...