### PR TITLE
Fix uniqnum for IVNV or UVNVs on Perl 5.6

### DIFF
--- a/t/uniqnum.t
+++ b/t/uniqnum.t
@@ -291,7 +291,9 @@ SKIP: {
 }
 
 # uniqnum not confused by IV'ified floats
-{
+SKIP: {
+    # This fails on 5.6 and isn't fixable without breaking a lot of other tests
+    skip 'This perl version gets confused by IVNV dualvars', 1 if $] lt '5.008000';
     my @nums = ( 2.1, 2.2, 2.3 );
     my $dummy = sprintf "%d", $_ for @nums;
 

--- a/t/uniqnum.t
+++ b/t/uniqnum.t
@@ -292,11 +292,11 @@ SKIP: {
 
 # uniqnum not confused by IV'ified floats
 {
-  my @nums = ( 2.1, 2.2, 2.3 );
-  my $dummy = sprintf "%d", $_ for @nums;
+    my @nums = ( 2.1, 2.2, 2.3 );
+    my $dummy = sprintf "%d", $_ for @nums;
 
-  # All @nums now have both NOK and IOK but IV=2 in each case
-  is( scalar( uniqnum @nums ), 3, 'uniqnum not confused by dual IV+NV' );
+    # All @nums now have both NOK and IOK but IV=2 in each case
+    is( scalar( uniqnum @nums ), 3, 'uniqnum not confused by dual IV+NV' );
 }
 
 {


### PR DESCRIPTION
Check specifically for absence of NOK flag on perl 5.6 when looking at IOK or UOK in case of IVNV or UVNV dualvars