### PR TITLE
Add a `uniqint()` function

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1306,6 +1306,7 @@ void
 uniq(...)
 PROTOTYPE: @
 ALIAS:
+    uniqint = 0
     uniqstr = 1
     uniq    = 2
 CODE:
@@ -1346,6 +1347,12 @@ CODE:
                 ST(retcount) = arg;
             retcount++;
             continue;
+        }
+        if(ix == 0) {
+            /* uniqint */
+            /* coerce to integer */
+            arg = sv_2mortal(SvUOK(arg) ? newSVuv(SvUV(arg)) :
+                                          newSViv(SvIV(arg)));
         }
 #ifdef HV_FETCH_EMPTY_HE
         he = (HE*) hv_common(seen, arg, NULL, 0, 0, HV_FETCH_LVALUE | HV_FETCH_EMPTY_HE, NULL, 0);

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1351,7 +1351,10 @@ CODE:
         if(ix == 0) {
             /* uniqint */
             /* coerce to integer */
+#if PERL_VERSION >= 8
+            /* int_amg only appeared in perl 5.8.0 */
             if(!SvAMAGIC(arg) || !(arg = AMG_CALLun(arg, int)))
+#endif
                 arg = sv_2mortal(SvUOK(arg) ? newSVuv(SvUV(arg)) :
                                               newSViv(SvIV(arg)));
         }

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1351,8 +1351,9 @@ CODE:
         if(ix == 0) {
             /* uniqint */
             /* coerce to integer */
-            arg = sv_2mortal(SvUOK(arg) ? newSVuv(SvUV(arg)) :
-                                          newSViv(SvIV(arg)));
+            if(!SvAMAGIC(arg) || !(arg = AMG_CALLun(arg, int)))
+                arg = sv_2mortal(SvUOK(arg) ? newSVuv(SvUV(arg)) :
+                                              newSViv(SvIV(arg)));
         }
 #ifdef HV_FETCH_EMPTY_HE
         he = (HE*) hv_common(seen, arg, NULL, 0, 0, HV_FETCH_LVALUE | HV_FETCH_EMPTY_HE, NULL, 0);

--- a/lib/List/Util.pm
+++ b/lib/List/Util.pm
@@ -13,7 +13,7 @@ require Exporter;
 our @ISA        = qw(Exporter);
 our @EXPORT_OK  = qw(
   all any first min max minstr maxstr none notall product reduce reductions sum sum0
-  sample shuffle uniq uniqnum uniqstr
+  sample shuffle uniq uniqint uniqnum uniqstr
   head tail pairs unpairs pairkeys pairvalues pairmap pairgrep pairfirst
 );
 our $VERSION    = "1.54";
@@ -57,7 +57,7 @@ List::Util - A selection of general-utility list subroutines
 
       pairs unpairs pairkeys pairvalues pairfirst pairgrep pairmap
 
-      shuffle uniq uniqnum uniqstr
+      shuffle uniq uniqint uniqnum uniqstr
     );
 
 =head1 DESCRIPTION
@@ -552,6 +552,28 @@ The C<undef> value is treated by this function as distinct from the empty
 string, and no warning will be produced. It is left as-is in the returned
 list. Subsequent C<undef> values are still considered identical to the first,
 and will be removed.
+
+=head2 uniqint
+
+    my @subset = uniqint @values
+
+I<Since version 1.55.>
+
+Filters a list of values to remove subsequent duplicates, as judged by an
+integer numerical equality test. Preserves the order of unique elements, and
+retains the first value of any duplicate set. Values in the returned list will
+be coerced into integers.
+
+    my $count = uniqint @values
+
+In scalar context, returns the number of elements that would have been
+returned as a list.
+
+Note that C<undef> is treated much as other numerical operations treat it; it
+compares equal to zero but additionally produces a warning if such warnings
+are enabled (C<use warnings 'uninitialized';>). In addition, an C<undef> in
+the returned list is coerced into a numerical zero, so that the entire list of
+values returned by C<uniqint> are well-behaved as integers.
 
 =head2 uniqnum
 

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use Config; # to determine ivsize
-use Test::More tests => 29;
+use Test::More tests => 30;
 use List::Util qw( uniqstr uniqint uniq );
 
 use Tie::Array;
@@ -141,6 +141,21 @@ is( scalar( uniqstr qw( a b c d a b e ) ), 5, 'uniqstr() in scalar context' );
     is_deeply( [ map "$_", uniqstr @strs ],
                [ map "$_", $strs[0], $strs[2] ],
                'uniqstr respects stringify overload' );
+}
+
+{
+    package Googol;
+
+    use overload '""' => sub { "1" . ( "0"x100 ) },
+                 'int' => sub { $_[0] };
+
+    sub new { bless {}, $_[0] }
+
+    package main;
+
+    is_deeply( [ uniqint( Googol->new, Googol->new ) ],
+               [ "1" . ( "0"x100 ) ],
+               'uniqint respects int overload' );
 }
 
 {

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -143,7 +143,9 @@ is( scalar( uniqstr qw( a b c d a b e ) ), 5, 'uniqstr() in scalar context' );
                'uniqstr respects stringify overload' );
 }
 
-{
+SKIP: {
+    skip('int overload requires perl version 5.8.0', 1) unless $] ge "5.008000";
+
     package Googol;
 
     use overload '""' => sub { "1" . ( "0"x100 ) },

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -98,9 +98,11 @@ is_deeply( [ uniqint 6.1, 6.2, 6.3 ],
                'uniqint on undef coerces to zero' );
 }
 
-{
+SKIP: {
+    skip('UVs are not reliable on this perl version', 1) unless $] ge "5.008000";
+
     # An integer guaranteed to be a UV
-    my $uv = int( 1 << ( $Config{ivsize}*8 - 1 ) );
+    my $uv = 1 << ( $Config{ivsize}*8 - 1 );
     is_deeply( [ uniqint $uv, $uv + 1 ],
                [ $uv, $uv + 1 ],
                'uniqint copes with UVs' );

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -2,9 +2,9 @@
 
 use strict;
 use warnings;
-use Config; # to determine nvsize
-use Test::More tests => 21;
-use List::Util qw( uniqstr uniq );
+use Config; # to determine ivsize
+use Test::More tests => 29;
+use List::Util qw( uniqstr uniqint uniq );
 
 use Tie::Array;
 
@@ -65,6 +65,45 @@ SKIP: {
     }
 
     is( $warnings, "", 'No warnings are printed when handling Unicode strings' );
+}
+
+is_deeply( [ uniqint ],
+           [],
+           'uniqint of empty list' );
+
+is_deeply( [ uniqint 5, 5 ],
+           [ 5 ],
+           'uniqint of repeated-element list' );
+
+is_deeply( [ uniqint 1, 2, 1, 3 ],
+           [ 1, 2, 3 ],
+           'uniqint removes subsequent duplicates' );
+
+is_deeply( [ uniqint 6.1, 6.2, 6.3 ],
+           [ 6 ],
+           'uniqint compares as and returns integers' );
+
+{
+    my $warnings = "";
+    local $SIG{__WARN__} = sub { $warnings .= join "", @_ };
+
+    is_deeply( [ uniqint 0, undef ],
+               [ 0 ],
+               'uniqint considers undef and zer0 equivalent' );
+
+    ok( length $warnings, 'uniqint on undef yields a warning' );
+
+    is_deeply( [ uniqint undef ],
+               [ 0 ],
+               'uniqint on undef coerces to zero' );
+}
+
+{
+    # An integer guaranteed to be a UV
+    my $uv = 1 << ( $Config{ivsize}*8 - 1 );
+    is_deeply( [ uniqint $uv, $uv + 1 ],
+               [ $uv, $uv + 1 ],
+               'uniqint copes with UVs' );
 }
 
 is_deeply( [ uniq () ],

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -89,7 +89,7 @@ is_deeply( [ uniqint 6.1, 6.2, 6.3 ],
 
     is_deeply( [ uniqint 0, undef ],
                [ 0 ],
-               'uniqint considers undef and zer0 equivalent' );
+               'uniqint considers undef and zero equivalent' );
 
     ok( length $warnings, 'uniqint on undef yields a warning' );
 

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -100,7 +100,7 @@ is_deeply( [ uniqint 6.1, 6.2, 6.3 ],
 
 {
     # An integer guaranteed to be a UV
-    my $uv = 1 << ( $Config{ivsize}*8 - 1 );
+    my $uv = int( 1 << ( $Config{ivsize}*8 - 1 ) );
     is_deeply( [ uniqint $uv, $uv + 1 ],
                [ $uv, $uv + 1 ],
                'uniqint copes with UVs' );


### PR DESCRIPTION
To smooth over most of the complications of `uniqnum()` when you know your numbers should be well-behaved integers.