### PR TITLE
Correct refcount handling on hv_store_ent to PL_DBsub in set_subname

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -2029,12 +2029,13 @@ PPCODE:
         }
 
         if (old_data && HeVAL(old_data)) {
+            SV* old_val = HeVAL(old_data);
             SV* new_full_name = sv_2mortal(newSVpvn_flags(HvNAME(stash), HvNAMELEN_get(stash), HvNAMEUTF8(stash) ? SVf_UTF8 : 0));
             sv_catpvn(new_full_name, "::", 2);
             sv_catpvn_flags(new_full_name, nameptr, s - nameptr, utf8flag ? SV_CATUTF8 : SV_CATBYTES);
-            SvREFCNT_inc(HeVAL(old_data));
-            if (hv_store_ent(DBsub, new_full_name, HeVAL(old_data), 0) != NULL)
-                SvREFCNT_inc(HeVAL(old_data));
+            SvREFCNT_inc(old_val);
+            if (!hv_store_ent(DBsub, new_full_name, old_val, 0))
+                SvREFCNT_dec(old_val);
         }
     }
 


### PR DESCRIPTION
The code had been handling the return value from hv_store_ent incorrectly.
hv_store_ent returns NULL if the store didn't happen (a tied hash), or if
the store operation failed - in other words, it returns true *if* it took
ownership of a reference to the stored value, false if not. This entire API
is somewhat clunky and error prone, and also somewhat makework, as store
never returns NULL on a valid untied hash - it will always succeed, or
croak if memory allocation fails.

This is a regression introduced in 2016 as part of commit a50a854f07ccc665:
    Fix %DB::sub for subs with non-Latin1 characters

That commit refactored the code from hv_store to hv_store_ent - a sensible
choice, as the latter API is more efficient - but introduced two small
errors not present in the previous code - inverting sense the truth test on
the return from hv_store_ent, and changing a SvREFCNT_dec to a SvREFCNT_inc.
Hence it would "leak" one reference count.

Experimentation suggests that this code doesn't cause obvious problems if it
is actually wrong. The code is adding another key that points to a value
already in the hash, and (intending) to have the correct reference count
manipulations to reflect this. Because all entries in the hash persist until
interpreter exit, and nothing deletes from the hash, in general "leaking" a
reference count won't make a difference as the SV already persists for the
lifetime of the interpreter. Likewise, deliberately introducing a different
bug into this code and *not* increasing the reference count also triggers no
warnings or errors, because the existing entry in the hash keeps the (new,
aliased) value "alive" for the lifetime of the hash.

Hence why this hasn't been noticed.