### PR TITLE
The minimum Perl version is v5.6.0, which supports weak references

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1767,11 +1767,7 @@ weaken(sv)
     SV *sv
 PROTOTYPE: $
 CODE:
-#ifdef SvWEAKREF
     sv_rvweaken(sv);
-#else
-    croak("weak references are not implemented in this release of perl");
-#endif
 
 void
 unweaken(sv)
@@ -1783,7 +1779,7 @@ CODE:
 #if defined(sv_rvunweaken)
     PERL_UNUSED_VAR(tsv);
     sv_rvunweaken(sv);
-#elif defined(SvWEAKREF)
+#else
     /* This code stolen from core's sv_rvweaken() and modified */
     if (!SvOK(sv))
         return;
@@ -1809,8 +1805,6 @@ CODE:
     SvRV_set(sv, SvREFCNT_inc_NN(tsv));
     SvROK_on(sv);
 #endif
-#else
-    croak("weak references are not implemented in this release of perl");
 #endif
 
 void
@@ -1818,12 +1812,8 @@ isweak(sv)
     SV *sv
 PROTOTYPE: $
 CODE:
-#ifdef SvWEAKREF
     ST(0) = boolSV(SvROK(sv) && SvWEAKREF(sv));
     XSRETURN(1);
-#else
-    croak("weak references are not implemented in this release of perl");
-#endif
 
 int
 readonly(sv)
@@ -2101,7 +2091,7 @@ BOOT:
     HV *lu_stash = gv_stashpvn("List::Util", 10, TRUE);
     GV *rmcgv = *(GV**)hv_fetch(lu_stash, "REAL_MULTICALL", 14, TRUE);
     SV *rmcsv;
-#if !defined(SvWEAKREF) || !defined(SvVOK)
+#if !defined(SvVOK)
     HV *su_stash = gv_stashpvn("Scalar::Util", 12, TRUE);
     GV *vargv = *(GV**)hv_fetch(su_stash, "EXPORT_FAIL", 11, TRUE);
     AV *varav;
@@ -2112,10 +2102,6 @@ BOOT:
     if(SvTYPE(rmcgv) != SVt_PVGV)
         gv_init(rmcgv, lu_stash, "List::Util", 10, TRUE);
     rmcsv = GvSVn(rmcgv);
-#ifndef SvWEAKREF
-    av_push(varav, newSVpv("weaken",6));
-    av_push(varav, newSVpv("isweak",6));
-#endif
 #ifndef SvVOK
     av_push(varav, newSVpv("isvstring",9));
 #endif

--- a/lib/Scalar/Util.pm
+++ b/lib/Scalar/Util.pm
@@ -36,11 +36,6 @@ unless (defined &isvstring) {
 }
 
 sub export_fail {
-  if (grep { /^(?:weaken|isweak)$/ } @_ ) {
-    require Carp;
-    Carp::croak("Weak references are not implemented in the version of perl");
-  }
-
   if (grep { /^isvstring$/ } @_ ) {
     require Carp;
     Carp::croak("Vstrings are not implemented in the version of perl");
@@ -323,11 +318,6 @@ Return true if C<$var> is tainted.
 Module use may give one of the following errors during import.
 
 =over
-
-=item Weak references are not implemented in the version of perl
-
-The version of perl that you are using does not implement weak references, to
-use L</isweak> or L</weaken> you will need to use a newer release of perl.
 
 =item Vstrings are not implemented in the version of perl
 


### PR DESCRIPTION
Hence remove all the conditional logic and documentation for supporting
earlier versions of Perl which did not have weak references.