### PR TITLE
Fix Perl Issue #19429: Scalar-List-Utils: fix signed/unsigned comparison warnings

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1584,10 +1584,10 @@ ALIAS:
     mesh_longest  = ZIP_MESH_LONGEST
     mesh_shortest = ZIP_MESH_SHORTEST
 PPCODE:
-    int nlists = items; /* number of lists */
+    Size_t nlists = items; /* number of lists */
     AV **lists;         /* inbound lists */
-    int len = 0;        /* length of longest inbound list = length of result */
-    int i;
+    Size_t len = 0;        /* length of longest inbound list = length of result */
+    Size_t i;
     bool is_mesh = (ix & ZIP_MESH);
     ix &= ~ZIP_MESH;
 
@@ -1628,12 +1628,12 @@ PPCODE:
     }
 
     if(is_mesh) {
-        int retcount = len * nlists;
+        SSize_t retcount = (SSize_t)(len * nlists);
 
         EXTEND(SP, retcount);
 
         for(i = 0; i < len; i++) {
-            int listi;
+            Size_t listi;
 
             for(listi = 0; listi < nlists; listi++) {
                 SV *item = (i < av_count(lists[listi])) ?
@@ -1647,10 +1647,10 @@ PPCODE:
         XSRETURN(retcount);
     }
     else {
-        EXTEND(SP, len);
+        EXTEND(SP, (SSize_t)len);
 
         for(i = 0; i < len; i++) {
-            int listi;
+            Size_t listi;
             AV *ret = newAV();
             av_extend(ret, nlists);
 

--- a/lib/List/Util.pm
+++ b/lib/List/Util.pm
@@ -16,7 +16,7 @@ our @EXPORT_OK  = qw(
   sample shuffle uniq uniqint uniqnum uniqstr zip zip_longest zip_shortest mesh mesh_longest mesh_shortest
   head tail pairs unpairs pairkeys pairvalues pairmap pairgrep pairfirst
 );
-our $VERSION    = "1.60";
+our $VERSION    = "1.61";
 our $XS_VERSION = $VERSION;
 $VERSION =~ tr/_//d;
 

--- a/lib/List/Util/XS.pm
+++ b/lib/List/Util/XS.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use List::Util;
 
-our $VERSION = "1.60";       # FIXUP
+our $VERSION = "1.61";       # FIXUP
 $VERSION =~ tr/_//d;         # FIXUP
 
 1;

--- a/lib/Scalar/Util.pm
+++ b/lib/Scalar/Util.pm
@@ -17,7 +17,7 @@ our @EXPORT_OK = qw(
   dualvar isdual isvstring looks_like_number openhandle readonly set_prototype
   tainted
 );
-our $VERSION    = "1.60";
+our $VERSION    = "1.61";
 $VERSION =~ tr/_//d;
 
 require List::Util; # List::Util loads the XS

--- a/lib/Sub/Util.pm
+++ b/lib/Sub/Util.pm
@@ -15,7 +15,7 @@ our @EXPORT_OK = qw(
   subname set_subname
 );
 
-our $VERSION    = "1.60";
+our $VERSION    = "1.61";
 $VERSION =~ tr/_//d;
 
 require List::Util; # as it has the XS


### PR DESCRIPTION
When building blead Scalar-List-Utils 1.60 throws warnings:

ListUtil.xs: In function ‘XS_List__Util_zip’:
ListUtil.xs:1619:33: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
		 if(av_count(av) > len)
				 ^
ListUtil.xs:1624:33: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
		 if(av_count(av) < len)
				 ^
ListUtil.xs:1639:31: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
		 SV *item = (i < av_count(lists[listi])) ?
			       ^
ListUtil.xs:1658:31: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
		 SV *item = (i < av_count(lists[listi])) ?
			       ^
Perl_av_count is defined to return a Size_t, which fits its
purpose of returning the number of items in the array which
cannot be negative.

This patch fixes those warnings by making the internal variables
to be of type Size_t as well. This alone will make the EXTEND()
macros warn, so counts passed in must be kept as SSize_t, requiring
some casting.

See Also:
	https://github.com/Perl/perl5/issues/19429
	https://github.com/Perl/perl5/pull/19430