### PR TITLE
Skip the tainted tests if your perl was built without taint support

### DIFF
--- a/t/tainted.t
+++ b/t/tainted.t
@@ -3,9 +3,17 @@
 use strict;
 use warnings;
 
-use Test::More tests => 5;
-
+use Config;
+use Test::More;
 use Scalar::Util qw(tainted);
+
+if (exists($Config{taint_support}) && not $Config{taint_support}) {
+    plan skip_all => "your perl was built without taint support";
+}
+else {
+    plan tests => 5;
+}
+
 
 ok( !tainted(1), 'constant number');
 


### PR DESCRIPTION
Hi,

I'm working on changes to the Configure script, to make it easy to build a perl that doesn't have taint support.

This PR changes `t/taint.t` to skip all tests if being installed on such a perl.

Cheers,
Neil