### PR TITLE
Fixed typo in isweak() pod section.

### DIFF
--- a/lib/Scalar/Util.pm
+++ b/lib/Scalar/Util.pm
@@ -230,7 +230,7 @@ B<NOTE>: Copying a weak reference creates a normal, strong, reference.
     $weak = isweak($copy);              # false
 
 I<Since Perl version 5.35.7> an equivalent function is available as
-C<builtin::isweak>.
+C<builtin::is_weak>.
 
 =head1 OTHER FUNCTIONS
 


### PR DESCRIPTION
Hi Team,

I noticed typo in the pod section for is_weak(), where it says it is equivalent to builtin::isweak rather builtin::is_weak.

Please review the change.

Many Thanks.

Best Regards,
Mohammad