### PR TITLE
Skip taint tests when -DSILENT_NO_TAINT_SUPPORT is enabled.

### DIFF
--- a/t/tainted.t
+++ b/t/tainted.t
@@ -7,7 +7,10 @@ use Config;
 use Test::More;
 use Scalar::Util qw(tainted);
 
-if (exists($Config{taint_support}) && not $Config{taint_support}) {
+if (
+    (exists($Config{taint_support}) && not $Config{taint_support}) ||
+    $Config{ccflags} =~ /-DSILENT_NO_TAINT_SUPPORT/
+) {
     plan skip_all => "your perl was built without taint support";
 }
 else {


### PR DESCRIPTION
If perl is built with -DSILENT_NO_TAINT_SUPPORT checking `$Config{taint_support}` isn't enough, this adds a check that looks for -DSILENT_NO_TAINT_SUPPORT in `$Config{ccflags}`.