### PR TITLE
Don't loop forever in uniqnum.t

### DIFF
--- a/t/uniqnum.t
+++ b/t/uniqnum.t
@@ -190,7 +190,10 @@ is_deeply( [ uniqnum @in],
 # Hard to know for sure what an Inf is going to be. Lets make one
 my $Inf = 0 + 1E1000;
 my $NaN;
-$Inf **= 1000 while ( $NaN = $Inf - $Inf ) == $NaN;
+for (1..10) {
+    $Inf **= 1000;
+    last unless ( $NaN = $Inf - $Inf ) == $NaN;
+}
 
 is_deeply( [ uniqnum 0, 1, 12345, $Inf, -$Inf, $NaN, 0, $Inf, $NaN ],
            [ 0, 1, 12345, $Inf, -$Inf, $NaN ],


### PR DESCRIPTION
If infinities are not working, make sure we fail after a few tries rather than looping infinitely to find infinity. 10 iterations is arbitrary -- 1 is likely enough in most cases.