### PR TITLE
Use builtin:: functions where available

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1717,6 +1717,7 @@ CODE:
     ST(0) = boolSV((SvPOK(sv) || SvPOKp(sv)) && (SvNIOK(sv) || SvNIOKp(sv)));
     XSRETURN(1);
 
+#if !PERL_VERSION_GE(5, 40, 0)
 SV *
 blessed(sv)
     SV *sv
@@ -1819,6 +1820,8 @@ PROTOTYPE: $
 CODE:
     ST(0) = boolSV(SvROK(sv) && SvWEAKREF(sv));
     XSRETURN(1);
+
+#endif /* !PERL_VERSION_GE(5, 40, 0) */
 
 int
 readonly(sv)

--- a/lib/Scalar/Util.pm
+++ b/lib/Scalar/Util.pm
@@ -23,6 +23,19 @@ $VERSION =~ tr/_//d;
 require List::Util; # List::Util loads the XS
 List::Util->VERSION( $VERSION ); # Ensure we got the right XS version (RT#100863)
 
+if( $] >= 5.040 ) {
+  # On Perl 5.40 and above, these builtins are stable, so we can use them
+  # instead of our own XS implementation
+
+  # Using this instead of a globref means we don't create an empty
+  # "builtins::" glob on older perls
+  no strict 'refs';
+  my $builtins = \%{"builtin::"};
+
+  *$_ = \&{ $builtins->{$_} } for (qw( blessed refaddr reftype weaken unweaken ));
+  *isweak = \&{ $builtins->{is_weak} };  # renamed
+}
+
 # populating @EXPORT_FAIL is done in the XS code
 sub export_fail {
   if (grep { /^isvstring$/ } @_ ) {


### PR DESCRIPTION
On Perl 5.40 and above, use the various `builtin::` functions to provide those in `Scalar::Util`, avoiding the need for our own custom xsubs in that case