### PR TITLE
fix precedence issue in uniqnum.t

### DIFF
--- a/t/uniqnum.t
+++ b/t/uniqnum.t
@@ -215,7 +215,7 @@ SKIP: {
         }
         if (eval {
             my $nanish = "$NaN" + 0;
-            $nanish != 0 && !$nanish != $NaN;
+            $nanish != 0 && $nanish != $NaN && $nanish != $nanish;
         }) {
             push @nums, $NaN;
         }


### PR DESCRIPTION
The test `!$nanish != $NaN` doesn't make much sense: It checks whether a boolean (effectively 0 or 1) is not equal to `$NaN`, which is always true. (Also, we know `$nanish != 0` from the preceding test, so `!$nanish` could be hardcoded as 0 here.)

Instead test whether `$NaN` correctly round-trips through strings, i.e. whether `$nanish` behaves like a proper NaN again (being non-equal to both the original `$NaN` and itself).