### PR TITLE
add Scalar::List::Utils module to match dist name

### DIFF
--- a/lib/Scalar/List/Utils.pm
+++ b/lib/Scalar/List/Utils.pm
@@ -1,0 +1,43 @@
+package Scalar::List::Utils;
+use strict;
+use warnings;
+
+our $VERSION    = "1.63";
+$VERSION =~ tr/_//d;
+
+1;
+
+__END__
+
+=head1 NAME
+
+Scalar::List::Utils - A distribution of general-utility subroutines
+
+=head1 SYNOPSIS
+
+    use Scalar::Util qw(blessed);
+    use List::Util qw(any);
+
+=head1 DESCRIPTION
+
+C<Scalar::List::Utils> does nothing on its own. It is packaged with several
+useful modules.
+
+=head1 MODULES
+
+=head2 L<List::Util>
+
+L<List::Util> contains a selection of useful subroutines for operating on lists
+of values.
+
+=head2 L<Scalar::Util>
+
+L<Scalar::Util> contains a selection of useful subroutines for interrogating
+or manipulating scalar values.
+
+=head2 L<Sub::Util>
+
+L<Sub::Util> contains a selection of useful subroutines for interrogating
+or manipulating subroutine references.
+
+=cut


### PR DESCRIPTION
Various tools expect to be able to translate distribution names to module names. That isn't always true, but it's helpful when it can be.

Add a Scalar::List::Utils module to match the dist name, including links to the other included modules.