### PR TITLE
fix string comparisons with $] to use numeric comparison instead

### DIFF
--- a/t/stack-corruption.t
+++ b/t/stack-corruption.t
@@ -1,7 +1,7 @@
 #!./perl
 
 BEGIN {
-    if ($] eq "5.008009" or $] eq "5.010000" or $] le "5.006002") {
+    if ("$]" == 5.008009 or "$]" == 5.010000 or "$]" <= 5.006002) {
         print "1..0 # Skip: known to fail on $]\n";
         exit 0;
     }

--- a/t/sum.t
+++ b/t/sum.t
@@ -98,7 +98,7 @@ SKIP: {
   cmp_ok($t, 'gt', 1152921504606846976, 'sum uses IV where it can'); # string comparison because Perl 5.6 does not compare it numerically correctly
 
   SKIP: {
-    skip "known to fail on $]", 1 if $] le "5.006002";
+    skip "known to fail on $]", 1 if "$]" <= 5.006002;
     $t = sum(1<<60, 1);
     cmp_ok($t, '>', 1<<60, 'sum uses IV where it can');
   }

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -44,7 +44,7 @@ is_deeply( [ uniqstr qw( 1 1.0 1E0 ) ],
 }
 
 SKIP: {
-    skip 'Perl 5.007003 with utf8::encode is required', 3 if $] lt "5.007003";
+    skip 'Perl 5.007003 with utf8::encode is required', 3 if "$]" < 5.007003;
     my $warnings = "";
     local $SIG{__WARN__} = sub { $warnings .= join "", @_ };
 
@@ -99,7 +99,7 @@ is_deeply( [ uniqint 6.1, 6.2, 6.3 ],
 }
 
 SKIP: {
-    skip('UVs are not reliable on this perl version', 2) unless $] ge "5.008000";
+    skip('UVs are not reliable on this perl version', 2) unless "$]" >= 5.008000;
 
     my $maxbits = $Config{ivsize} * 8 - 1;
 
@@ -153,7 +153,7 @@ is( scalar( uniqstr qw( a b c d a b e ) ), 5, 'uniqstr() in scalar context' );
 }
 
 SKIP: {
-    skip('int overload requires perl version 5.8.0', 1) unless $] ge "5.008000";
+    skip('int overload requires perl version 5.8.0', 1) unless "$]" >= 5.008000;
 
     package Googol;
 

--- a/t/uniqnum.t
+++ b/t/uniqnum.t
@@ -296,7 +296,7 @@ SKIP: {
 # uniqnum not confused by IV'ified floats
 SKIP: {
     # This fails on 5.6 and isn't fixable without breaking a lot of other tests
-    skip 'This perl version gets confused by IVNV dualvars', 1 if $] lt '5.008000';
+    skip 'This perl version gets confused by IVNV dualvars', 1 if "$]" <= 5.008000;
     my @nums = ( 2.1, 2.2, 2.3 );
     my $dummy = sprintf "%d", $_ for @nums;
 


### PR DESCRIPTION
The fix follows Zefram's suggestion from
https://www.nntp.perl.org/group/perl.perl5.porters/2012/05/msg186846.html

> On older perls, however, $] had a numeric value that was built up using
> floating-point arithmetic, such as 5+0.006+0.000002.  This would not
> necessarily match the conversion of the complete value from string form
> [perl #72210].  You can work around that by explicitly stringifying
> $] (which produces a correct string) and having *that* numify (to a
> correctly-converted floating point value) for comparison.  I cultivate
> the habit of always stringifying $] to work around this, regardless of
> the threshold where the bug was fixed.  So I'd write
>
>     use if "$]" >= 5.014, warnings => "non_unicode";

This ensures that the comparisons will still work when Perl's major version changes to anything greater than 9.