### PR TITLE
Fix uniqint SIGSEGV for objects with no int overload

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1369,8 +1369,9 @@ CODE:
             /* coerce to integer */
 #if PERL_VERSION >= 8
             /* int_amg only appeared in perl 5.8.0 */
-            if(SvAMAGIC(arg) && (arg = AMG_CALLun(arg, int)))
-                ; /* nothing to do */
+            SV *tmpsv;
+            if(SvAMAGIC(arg) && (tmpsv = AMG_CALLun(arg, int)))
+                arg = tmpsv;
             else
 #endif
             if(!SvOK(arg) || SvNOK(arg) || SvPOK(arg))

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use Config; # to determine ivsize
-use Test::More tests => 31;
+use Test::More tests => 35;
 use List::Util qw( uniqstr uniqint uniq );
 
 use Tie::Array;
@@ -96,6 +96,31 @@ is_deeply( [ uniqint 6.1, 6.2, 6.3 ],
     is_deeply( [ uniqint undef ],
                [ 0 ],
                'uniqint on undef coerces to zero' );
+}
+
+{
+    use Math::BigInt;
+    my ($obj1, $obj2) = map { Math::BigInt->new($_) } 5, 10;
+
+    is_deeply( [ uniqint $obj1, $obj1 ],
+               [ $obj1 ],
+               'uniqint removes repeated Math::BigInt objects' );
+
+    is_deeply( [ uniqint $obj1, $obj1, $obj2, $obj2 ],
+               [ $obj1, $obj2 ],
+               'uniqint removes subsequent Math::BigInt objects' );
+}
+
+{
+    my ($obj1, $obj2) = map { bless {}, "PackageWithoutIntOverload" } 1..2;
+
+    is_deeply( [ uniqint $obj1, $obj1 ],
+               [ $obj1 ],
+               'uniqint removes repeated objects with no int overload' );
+
+    is_deeply( [ uniqint $obj1, $obj1, $obj2, $obj2 ],
+               [ $obj1, $obj2 ],
+               'uniqint removes subsequent objects with no int overload' );
 }
 
 SKIP: {


### PR DESCRIPTION
In case uniqint takes several objects, it always tries to call their int overload using amagic_call.  This patch fixes the case when amagic_call returned NULL resulting into Segmentation Violation. Several tests are also added to ensure proper objects handling.

**Problem:**
The code below expected to work but crashes with SIGSEGV.
```perl
use List::Util qw( uniqint );
uniqint bless {}, __PACKAGE__; # given __PACKAGE__ has no 'int' overload unlike Math::BigInt
```

**Desired behaviour:**
Returns a list with single reference to an object.