### PR TITLE
Fix uniqint SIGSEGV for objects with no int overload

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1369,8 +1369,10 @@ CODE:
             /* coerce to integer */
 #if PERL_VERSION >= 8
             /* int_amg only appeared in perl 5.8.0 */
-            if(SvAMAGIC(arg) && (arg = AMG_CALLun(arg, int)))
-                ; /* nothing to do */
+            if(SvAMAGIC(arg)) {
+                if(!(arg = AMG_CALLun(arg, int)))
+                    croak("No \"int\" method found in overloaded package");
+            }
             else
 #endif
             if(!SvOK(arg) || SvNOK(arg) || SvPOK(arg))

--- a/t/uniq.t
+++ b/t/uniq.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use Config; # to determine ivsize
-use Test::More tests => 31;
+use Test::More tests => 35;
 use List::Util qw( uniqstr uniqint uniq );
 
 use Tie::Array;
@@ -96,6 +96,32 @@ is_deeply( [ uniqint 6.1, 6.2, 6.3 ],
     is_deeply( [ uniqint undef ],
                [ 0 ],
                'uniqint on undef coerces to zero' );
+}
+
+{
+    use Math::BigInt;
+    my ($obj1, $obj2, $obj3) = map { Math::BigInt->new($_) } 1, 1, 2;
+
+    is_deeply( [ uniqint $obj1, $obj1 ],
+               [ $obj1 ],
+               'uniqint removes repeated Math::BigInt objects' );
+
+    is_deeply( [ uniqint $obj1, $obj2 ],
+               [ $obj1 ],
+               'uniqint removes subsequent Math::BigInt objects' );
+
+    is_deeply( [ uniqint $obj1, $obj2, $obj3 ],
+               [ $obj1, $obj3 ],
+               'uniqint removes multiple subsequent Math::BigInt objects' );
+}
+
+{
+    { package OverloadedPackageWithoutInt; use overload "+" => sub {} }
+
+    my $obj1 = bless {}, "OverloadedPackageWithoutInt";
+
+    ok( !defined eval { uniqint $obj1 },
+        'package with no "int" overload throws exception' );
 }
 
 SKIP: {


### PR DESCRIPTION
In case uniqint takes several objects, it always tries to call their int overload using amagic_call.  This patch fixes the case when amagic_call returned NULL resulting into Segmentation Violation. Several tests are also added to ensure proper objects handling.

**Problem:**
The code below expected to work but crashes with SIGSEGV.
```perl
use List::Util qw( uniqint );
{ package Foo; use overload "+" => sub {1} }
uniqint bless {}, "Foo"; # Foo has no 'int' overload unlike Math::BigInt
```

```
| SvAMAGIC | AMG_CALLun | Current result | Proposed result |
+----------+------------+----------------+-----------------+
| false    | false      | else branch    | else branch     |
| false    | true       | else branch    | else branch     |
| true     | false      | SIGSEGV        | croak like int()|
| true     | true       | else bypassed  | else bypassed   |
```