### PR TITLE
always allow isvstring to be used

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1852,10 +1852,10 @@ CODE:
 #ifdef SvVOK
     SvGETMAGIC(sv);
     ST(0) = boolSV(SvVOK(sv));
-    XSRETURN(1);
 #else
-    croak("vstrings are not implemented in this release of perl");
+    ST(0) = boolSV(0);
 #endif
+    XSRETURN(1);
 
 SV *
 looks_like_number(sv)
@@ -2109,20 +2109,9 @@ BOOT:
     HV *lu_stash = gv_stashpvn("List::Util", 10, TRUE);
     GV *rmcgv = *(GV**)hv_fetch(lu_stash, "REAL_MULTICALL", 14, TRUE);
     SV *rmcsv;
-#if !defined(SvVOK)
-    HV *su_stash = gv_stashpvn("Scalar::Util", 12, TRUE);
-    GV *vargv = *(GV**)hv_fetch(su_stash, "EXPORT_FAIL", 11, TRUE);
-    AV *varav;
-    if(SvTYPE(vargv) != SVt_PVGV)
-        gv_init(vargv, su_stash, "Scalar::Util", 12, TRUE);
-    varav = GvAVn(vargv);
-#endif
     if(SvTYPE(rmcgv) != SVt_PVGV)
         gv_init(rmcgv, lu_stash, "List::Util", 10, TRUE);
     rmcsv = GvSVn(rmcgv);
-#ifndef SvVOK
-    av_push(varav, newSVpv("isvstring",9));
-#endif
 #ifdef REAL_MULTICALL
     sv_setsv(rmcsv, &PL_sv_yes);
 #else

--- a/lib/Scalar/Util.pm
+++ b/lib/Scalar/Util.pm
@@ -36,16 +36,6 @@ if( $] >= 5.040 ) {
   *isweak = \&{ $builtins->{is_weak} };  # renamed
 }
 
-# populating @EXPORT_FAIL is done in the XS code
-sub export_fail {
-  if (grep { /^isvstring$/ } @_ ) {
-    require Carp;
-    Carp::croak("Vstrings are not implemented in this version of perl");
-  }
-
-  @_;
-}
-
 # set_prototype has been moved to Sub::Util with a different interface
 sub set_prototype(&$)
 {

--- a/t/isvstring.t
+++ b/t/isvstring.t
@@ -4,17 +4,18 @@ use strict;
 use warnings;
 
 $|=1;
-use Scalar::Util ();
-use Test::More  (grep { /isvstring/ } @Scalar::Util::EXPORT_FAIL)
-    ? (skip_all => 'isvstring is not supported on this perl version')
-    : (tests => 3);
-
+use Test::More tests => 3;;
 use Scalar::Util qw(isvstring);
 
 my $vs = ord("A") == 193 ? 241.75.240 : 49.46.48;
 
 ok( $vs == "1.0", 'dotted num');
-ok( isvstring($vs), 'isvstring');
+if ($] >= 5.008000) {
+  ok( isvstring($vs), 'isvstring');
+}
+else {
+  ok( !isvstring($vs), "isvstring is false for all values on $]");
+}
 
 my $sv = "1.0";
 ok( !isvstring($sv), 'not isvstring');


### PR DESCRIPTION
On perl 5.6, the isvstring function would not allow itself to be called or exported. This behavior is annoying to implement, and forces loading Exporter::Heavy in all cases.

Instead, isvstring can just always return false on perl 5.6. This is an accurate behavior, as nothing on perl 5.6 is a vstring. And the odds of anyone caring about this specific behavior on a prehistoric version of perl is almost certainly 0.