### PR TITLE
re-instate ' in names, from 5.41.6 and later

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1951,7 +1951,7 @@ PREINIT:
     STRLEN namelen;
     const char* nameptr = SvPV(name, namelen);
     int utf8flag = SvUTF8(name);
-#if PERL_VERSION_LT(5, 41, 3)
+#if PERL_VERSION_LT(5, 41, 3) || PERL_VERSION_GT(5, 41, 5)
     int quotes_seen = 0;
     bool need_subst = FALSE;
 #endif
@@ -1977,12 +1977,12 @@ PPCODE:
         if (s > nameptr && *s == ':' && s[-1] == ':') {
             end = s - 1;
             begin = ++s;
-#if PERL_VERSION_LT(5, 41, 3)
+#if PERL_VERSION_LT(5, 41, 3) || PERL_VERSION_GT(5, 41, 5)
             if (quotes_seen)
                 need_subst = TRUE;
 #endif
         }
-#if PERL_VERSION_LT(5, 41, 3)
+#if PERL_VERSION_LT(5, 41, 3) || PERL_VERSION_GT(5, 41, 5)
         else if (s > nameptr && *s != '\0' && s[-1] == '\'') {
             end = s - 1;
             begin = s;
@@ -1993,7 +1993,7 @@ PPCODE:
     }
     s--;
     if (end) {
-#if PERL_VERSION_LT(5, 41, 3)
+#if PERL_VERSION_LT(5, 41, 3) || PERL_VERSION_GT(5, 41, 5)
         SV* tmp;
         if (need_subst) {
             STRLEN length = end - nameptr + quotes_seen - (*end == '\'' ? 1 : 0);

--- a/t/exotic_names.t
+++ b/t/exotic_names.t
@@ -45,7 +45,7 @@ sub caller3_ok {
         ),
     );
 
-    $expected =~ s/'/::/g if $] < 5.041_003;
+    $expected =~ s/'/::/g if $] < 5.041_003 || $] >= 5.041_006;
 
     # this is apparently how things worked before 5.16
     utf8::encode($expected) if $] < 5.016 and $ord > 255;
@@ -71,8 +71,8 @@ my @ordinal = (
     # 5.14 is the first perl to start properly handling \0 in identifiers
     ($] >= 5.014 ? ( 0 ) : ()),
     1 .. 38,
-    # single quote ' separators are deprecated in 5.37.9
-    ($] < 5.037009 ? ( 39 ) : ()),
+    # single quote ' separators are deprecated in 5.37.9, removed in 5.41.3, readded in 5.41.6
+    ($] < 5.037_009 || $] >= 5.041_006 ? ( 39 ) : ()),
     40 .. 255,
     # Unicode in 5.6 is not sane (crashes etc)
     ($] >= 5.008 ? (
@@ -85,7 +85,7 @@ my @ordinal = (
 
 my $legal_ident_char = join('',
     "A-Z_a-z0-9",
-    ($] < 5.037009 ? q['] : ()),
+    ($] < 5.037_009 || $] >= 5.041_006 ? q['] : ()),
     ($] > 5.008 ? (
         map chr, 0x100, 0x498
     ) : ()),


### PR DESCRIPTION
- ' was deprecated in 5.37.9, so we stopped testing for it, but code still supported it
- ' was removed entirely in 5.41.3, so we stopped supporting it in code
- ' was reinstated entirely in 5.41.6 (but behind a default-enabled feature), so we can support it in code and test for it again

This replaces #141 and https://github.com/Perl/perl5/pull/23500 -- after this is released as version 1.71, blead can then sync to it.