### PR TITLE
uniqnum: Update and remove undefined C behavior

### DIFF
--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1458,6 +1458,9 @@ CODE:
             SvNV(arg); /* SvIV() sets SVf_IOK even on floats on 5.6 */
 #endif
         }
+#ifndef NV_PRESERVES_UV_BITS
+#  define NV_PRESERVES_UV_BITS 53
+#endif
 #if PERL_VERSION < 6
 #  if NVSIZE > IVSIZE               /* $Config{nvsize} > $Config{ivsize} */
 #    define NV_PRESERVES_UV
@@ -1522,7 +1525,8 @@ CODE:
                  * are 1 && all other ("disallowed") bits are set to 0.                  *
                  * (If the value prior to subtraction was 0, then subtracting 1 will set *
                  * all bits - which is also fine.)                                       */
-                UV valid_bits = (lowest_set << 53) - 1;
+                UV valid_bits = (lowest_set << NV_PRESERVES_UV_BITS) - 1;
+
 
                 /* The value of arg can be exactly represented by a double unless one    *
                  * or more of its "disallowed" bits are set - ie if iv & (~valid_bits)   *

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1458,7 +1458,12 @@ CODE:
             SvNV(arg); /* SvIV() sets SVf_IOK even on floats on 5.6 */
 #endif
         }
-#if NVSIZE > IVSIZE                          /* $Config{nvsize} > $Config{ivsize} */
+#if PERL_VERSION < 6
+#  if NVSIZE > IVSIZE               /* $Config{nvsize} > $Config{ivsize} */
+#    define NV_PRESERVES_UV
+#  endif
+#endif
+#ifdef NV_PRESERVES_UV
         /* Avoid altering arg's flags */
         if(SvUOK(arg))      nv_arg = (NV)SvUV(arg);
         else if(SvIOK(arg)) nv_arg = (NV)SvIV(arg);

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1495,6 +1495,9 @@ CODE:
             sv_setpvn(keysv, (char *) &nv_arg, ACTUAL_NVSIZE);
         }
 #else                                    /* $Config{nvsize} == $Config{ivsize} == 8 */
+#  ifndef NEGATE_2UV    /* Assumes iv < 0; avoids undefined behavior if iv == IV_MIN */
+#    define NEGATE_2UV(iv) ((UV) -((iv) + 1) + 1U)
+#  endif
         if( SvIOK(arg) || !SvOK(arg) ) {
 
             /* It doesn't matter if SvUOK(arg) is TRUE */
@@ -1502,10 +1505,9 @@ CODE:
 
             /* use "0" for all zeros */
             if(iv == 0) sv_setpvs(keysv, "0");
-
             else {
                 int uok = SvUOK(arg);
-                int sign = ( iv > 0 || uok ) ? 1 : -1;
+                UV uv = (iv > 0 || uok) ? iv : NEGATE_2UV(iv);
 
                 /* Set keysv to the bytes of SvNV(arg) if and only if the integer value  *
                  * held by arg can be represented exactly as a double - ie if there are  *
@@ -1513,29 +1515,34 @@ CODE:
                  * most significant set bit.                                             *
                  * The neatest approach I could find was provided by roboticus at:       *
                  *     https://www.perlmonks.org/?node_id=11113490                       *
-                 * First, identify the lowest set bit and assign its value to an IV.     *
-                 * Note that this value will always be > 0, and always a power of 2.     * 
-                 *                                                                       *
+                 * First, identify the lowest set bit.  The word will look like          *
+                 * this, with a rightmost set bit in position 's':                       *
+                 * ('x's are the values above that bit, and 'y's are their               *
+                 * complements so 'x&y' yields 0)                                        *
+                 *               s                                                       *
+                 *  x..xxxxxxxxxx100..00      Original                                   *
+                 *  y..yyyyyyyyyy011..11      Complement                                 *
+                 *  y..yyyyyyyyyy100..00      Add 1                                      *
+                 *  0..0000000000100..00      AND with the original                      *
                  * (Yes, complementing and adding 1 is just taking the negative          *
-                 * on 2's complement machines, but not on 1's complement ones)           */
-                IV lowest_set = iv & (~iv + 1);
+                 * on 2's complement machines, but not on 1's complement ones,           *
+                 * and some compilers complain about negating an unsigned.)              */
+                UV lowest_set = uv & (~uv + 1);
 
-                /* Second, shift it left 53 bits to get location of the first bit        *
-                 * beyond arg's highest "allowed" set bit.                                                    *
-                 * NOTE: If lowest set bit is initially far enough left, then this left  *
-                 * shift operation will result in a value of 0, which is fine.           *
-                 * Then subtract 1 so that all of the ("allowed") bits below the set bit *
-                 * are 1 && all other ("disallowed") bits are set to 0.                  *
-                 * (If the value prior to subtraction was 0, then subtracting 1 will set *
-                 * all bits - which is also fine.)                                       */
-                UV valid_bits = (lowest_set << NV_PRESERVES_UV_BITS) - 1;
-
-
-                /* The value of arg can be exactly represented by a double unless one    *
-                 * or more of its "disallowed" bits are set - ie if iv & (~valid_bits)   *
-                 * is untrue. However, if (iv < 0 && !SvUOK(arg)) we need to multiply iv *
-                 * by -1 prior to performing that '&' operation - so multiply iv by sign.*/
-                if( !((iv * sign) & (~valid_bits)) ) {
+                /* Shift it left by the number of bits in the mantissa, let's            *
+                 * say the mantissa contains 9 bits                                      *
+                 *      |<--9-->|                                                        *
+                                 s                                                       *
+                 *  0..0000000000100..00   From above                                    *
+                 *  0..0100000000000..00   Shift                                         *
+                 *  0..0011111111111..11   Subtract 1                                    *
+                 *  1..1100000000000..00   Complement                                    *
+                 *  x..xx00000000000..00   AND with original                             *
+                 *                                                                       *
+                 * If the result is 0, all the 'x's were 0, meaning there were           *
+                 * no bits set outside what fits in the mantissa; otherwise it           *
+                 * can't be represented by an NV losslessly.                             */
+                if ((uv & (~ ((lowest_set << NV_PRESERVES_UV_BITS) - 1))) == 0) {
                     /* Avoid altering arg's flags */
                     nv_arg = uok ? (NV)SvUV(arg) : (NV)SvIV(arg);
                     sv_setpvn(keysv, (char *) &nv_arg, 8);

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1514,8 +1514,11 @@ CODE:
                  * The neatest approach I could find was provided by roboticus at:       *
                  *     https://www.perlmonks.org/?node_id=11113490                       *
                  * First, identify the lowest set bit and assign its value to an IV.     *
-                 * Note that this value will always be > 0, and always a power of 2.     */
-                IV lowest_set = iv & -iv;
+                 * Note that this value will always be > 0, and always a power of 2.     * 
+                 *                                                                       *
+                 * (Yes, complementing and adding 1 is just taking the negative          *
+                 * on 2's complement machines, but not on 1's complement ones)           */
+                IV lowest_set = iv & (~iv + 1);
 
                 /* Second, shift it left 53 bits to get location of the first bit        *
                  * beyond arg's highest "allowed" set bit.                                                    *

--- a/ListUtil.xs
+++ b/ListUtil.xs
@@ -1477,7 +1477,7 @@ CODE:
 
         /* for NaN, use the platform's normal stringification */
         else if (nv_arg != nv_arg) sv_setpvf(keysv, "%" NVgf, nv_arg);
-#ifdef NV_IS_DOUBLEDOUBLE
+#  ifdef NV_IS_DOUBLEDOUBLE
         /* If the least significant double is zero, it could be either 0.0     *
          * or -0.0. We therefore ignore the least significant double and       *
          * assign to keysv the bytes of the most significant double only.      */
@@ -1485,7 +1485,7 @@ CODE:
             double double_arg = (double)nv_arg;
             sv_setpvn(keysv, (char *) &double_arg, 8);
         }
-#endif
+#  endif
         else {
             /* Use the byte structure of the NV.                               *
              * ACTUAL_NVSIZE == sizeof(NV) minus the number of bytes           *


### PR DESCRIPTION
1.  Configure for all but ancient perls tells us if a UV can always losslelssly fit into an NV.   Use that if available.
2.  Configure for all but ancient perls tells us the mantissa width.  Use that if available instead of assuming it is 53.
3.  The code for `uniqnum` assumes this is a 2's complement machine.  Change to not assume that.
4. There were several undefined behaviors marked by running ASan on this code; all stemmed from using signed values, where unsigned would work.   There was an issue with abs(IV_MIN) not being representable in an IV on  a 2's complement machine; and left shifting a negative value is undefined.   
5.  I found myself drawing a picture to try to understand the behavior of  item 4.  And I think the picture is clearer than the previous comments. so I     changed to use it. 